### PR TITLE
FILETAGS vs TAGS

### DIFF
--- a/org-vscode/out/tags.js
+++ b/org-vscode/out/tags.js
@@ -44,10 +44,11 @@ module.exports = function () {
             const titleMatch = fileText.match(/^\#\+TITLE:\s*(.*)$/mi);
             const title = titleMatch ? titleMatch[1].trim() : file;
 
-            // Look for #+TAGS: or #+FILETAGS:
-            const match = fileText.match(/^\#\+(FILE)?TAGS:\s*(.*)$/mi);
+            // Look for file-level tags only. In Org-mode, #+FILETAGS are inherited by all entries in the file.
+            // Note: #+TAGS is primarily used to define/configure allowed tags (completion, keys, groups), not to tag the file.
+            const match = fileText.match(/^\#\+FILETAGS:\s*(.*)$/mi);
             if (match) {
-                const tagString = match[2];
+                const tagString = match[1];
                 const rawTags = tagString
                   .split(/[:,]/)
                   .map(tag => tag.trim().toUpperCase())


### PR DESCRIPTION
The background is this:

There are (well, at least :-) ) two different tags in org files: tags and `FILETAGS`.

The `FILETAGS` are per file but the tags can be on a headline as well (i.e. local), and finally `TAGS` specify the possible (local) tags for a file (sigh... for something like intellisense I think).

See also https://orgmode.org/manual/Tag-Inheritance.html where it says:

```
Tags make use of the hierarchical structure of outline trees. If a heading has a certain tag, all subheadings inherit the tag as well. For example, in the list

* Meeting with the French group      :work:
** Summary by Frank                  :boss:notes:
*** TODO Prepare slides for him      :action:

the final heading has the tags ‘work’, ‘boss’, ‘notes’, and ‘action’ even though the final heading is not explicitly marked with those tags. You can also set tags that all entries in a file should inherit just as if these tags were defined in a hypothetical level zero that surrounds the entire file. Use a line like this[50](https://orgmode.org/manual/Tag-Inheritance.html#FOOT50)

#+FILETAGS: :Peter:Boss:Secret:
```

```
Org supports tag insertion based on a list of tags. By default this list is constructed dynamically, containing all tags currently used in the buffer. You may also globally specify a hard list of tags with the variable org-tag-alist. Finally you can set the default tags for a given file using the ‘TAGS’ keyword, like

#+TAGS: @work @home @tennisclub
#+TAGS: laptop car pc sailboat
```

I think the comma-separated thing you support is not actually allowed in org (see above), but I left it in anyway for now.

I am really not sure how the semantics of `#+TAGS` is supposed to be--but I *think* it's just for intellisense and doesn't mean the file actually has those tags (yet). In that case, I think matching on `TAGS` for search is actually wrong. What do you think?

