### PR TITLE
dialogs: Show warnings as warnings, information as information.

### DIFF
--- a/org-vscode/out/showMessage.js
+++ b/org-vscode/out/showMessage.js
@@ -43,7 +43,7 @@ class WindowMessage {
                 });
             }
             else {
-                vscode.window.showErrorMessage(this.message);
+                vscode.window.showInformationMessage(this.message);
             }
         }
         else if (this.type === "warning") {
@@ -60,7 +60,7 @@ class WindowMessage {
                 });
             }
             else {
-                vscode.window.showErrorMessage(this.message);
+                vscode.window.showWarningMessage(this.message);
             }
         }
         else if (this.type === "error") {


### PR DESCRIPTION
Not sure why it was not like that :)