### PR TITLE
Make vsix smaller.

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,5 +1,6 @@
 .vscode/**
 .vscode-test/**
+.git/**
 out/test/**
 out/**/*.map
 src/**
@@ -7,3 +8,16 @@ src/**
 tsconfig.json
 vsc-extension-quickstart.md
 tslint.json
+Images/**
+node_modules/**
+org-vscode/out/**
+org-vscode/test/**
+org-vscode/scripts/**
+*.orig
+*.rej
+*.patch
+howto.md
+roadmap.md
+TYPESCRIPT
+CONTRIBUTING.md
+manifest.scm

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"orgMode",
 		"scheduler"
 	],
-	"main": "./out/extension",
+	"main": "./dist/extension.js",
 	"contributes": {
 		"configurationDefaults": {
 			"[vso]": {
@@ -588,15 +588,20 @@
 		]
 	},
 	"scripts": {
-		"postinstall": "node ./node_modules/vscode/bin/install && node ./scripts/fetch-media.js",
-		"fetch-media": "node ./scripts/fetch-media.js",
-		"test": "npm run compile && node ./node_modules/vscode/bin/test"
+		"postinstall": "node ./org-vscode/scripts/fetch-media.js",
+		"fetch-media": "node ./org-vscode/scripts/fetch-media.js",
+		"test": "node ./org-vscode/test/runTest.js",
+		"bundle": "esbuild ./org-vscode/out/extension.js --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --minify",
+		"package": "npm run bundle && node node_modules/.bin/vsce package"
 	},
 	"devDependencies": {
 		"@types/mocha": "^2.2.42",
-		"@types/node": "^8.10.66",
+		"@types/node": "^18.0.0",
+		"@types/vscode": "^1.70.0",
+		"@vscode/test-electron": "^2.3.8",
 		"typescript": "^5.5.4",
-		"vscode": "^1.1.21"
+		"@vscode/vsce": "^2.22.0",
+		"esbuild": "^0.27.1"
 	},
 	"dependencies": {
 		"fs-extra": "^7.0.0",


### PR DESCRIPTION
Superseded by #30.

#30 keeps the intent of this PR (smaller VSIX via `.vscodeignore` and bundling) but adds maintainer fixups:
- ensure `dist/` exists before esbuild runs
- run `bundle` before `test` and `postinstall`
- include updated `package-lock.json` since dependencies changed

Thanks for the work here — the VSIX size reduction is great.