### PR TITLE
Make org-roam opening by title simpler.

### DIFF
--- a/org-vscode/out/titles.js
+++ b/org-vscode/out/titles.js
@@ -41,7 +41,7 @@ module.exports = function () {
     function setQuickPick() {
         vscode.window.showQuickPick(titles.sort()).then((title) => {
             if (title && listObject[title]) {
-                let fullpath = path.join(setMainDir(), listObject[title]);
+                let fullpath = listObject[title];
                 vscode.workspace.openTextDocument(vscode.Uri.file(fullpath)).then(doc => {
                     vscode.window.showTextDocument(doc, vscode.ViewColumn.Beside, true);
                 });


### PR DESCRIPTION
Superseded by #31.

#26 is based on an older commit and includes unrelated packaging diffs (package-lock/package.json/.vscodeignore).

#31 contains only the requested nit from #13/#25:
- `listObject[title]` already stores the absolute path, so open it directly without `path.join(setMainDir(), …)`.