### PR TITLE
Make "date format" setting text reflect what it actually controls.

### DIFF
--- a/package.json
+++ b/package.json
@@ -310,9 +310,10 @@
 					"default": "MM-DD-YYYY",
 					"enum": [
 						"MM-DD-YYYY",
-						"DD-MM-YYYY"
+						"DD-MM-YYYY",
+						"YYYY-MM-DD"
 					],
-					"description": "The scheduled date format."
+					"description": "org file date format (YYYY-MM-DD is the Emacs Org-mode standard)"
 				}
 			}
 		},


### PR DESCRIPTION
Otherwise emacs users can't actually choose YYYY-MM-DD as the on-disk format. That YYYY-MM-DD is the emacs on-disk format.

Or did you solve it in another way?

I see a new functionality `org-vscode: Convert dates in current file`, hmm.