### PR TITLE
Add Guix container manifest

### DIFF
--- a/manifest.scm
+++ b/manifest.scm
@@ -1,0 +1,2 @@
+(packages->manifest
+  (specifications->packages (list "bash" "node" "node-esbuild" "esbuild")))


### PR DESCRIPTION
This is so I can build this extension in GNU Guix Linux distribution.

What it does is configure what packages are available in the (dev) container, so I can build it in isolation.

That would be the last thing I need from my fork, and as you can see it has very few packages it refers to, all stable.

Usage:

```
guix shell -C -N -m manifest.scm -- npm run package
```

Result: `.vsix` file was built.

Usage:

```
guix shell -C -N
```

Result: am in dev shell in a container with only those packages available.
