### PR TITLE
FILETAGS: Only support ":", no ",".

### DIFF
--- a/org-vscode/out/tags.js
+++ b/org-vscode/out/tags.js
@@ -50,7 +50,7 @@ module.exports = function () {
             if (match) {
                 const tagString = match[1];
                 const rawTags = tagString
-                  .split(/[:,]/)
+                  .split(/[:]/)
                   .map(tag => tag.trim().toUpperCase())
                   .filter(Boolean);
 


### PR DESCRIPTION
Follow-up to commit 73735ca0be373b60ba0daeec08e2a1bf99cddc9f.

Since we didn't support `FILETAGS` before and now we do and there was no release in-between, let's not unnecessarily support `,` on `FILETAGS`.
