### PR TITLE
Org-roam: open by title uses absolute path (supersedes #26)

### DIFF
--- a/org-vscode/out/titles.js
+++ b/org-vscode/out/titles.js
@@ -41,7 +41,7 @@ module.exports = function () {
     function setQuickPick() {
         vscode.window.showQuickPick(titles.sort()).then((title) => {
             if (title && listObject[title]) {
-                let fullpath = path.join(setMainDir(), listObject[title]);
+                let fullpath = listObject[title];
                 vscode.workspace.openTextDocument(vscode.Uri.file(fullpath)).then(doc => {
                     vscode.window.showTextDocument(doc, vscode.ViewColumn.Beside, true);
                 });


### PR DESCRIPTION
Supersedes #26 (which includes a large package-lock/package.json/.vscodeignore diff due to being based on an older commit).

This PR contains only the requested nit from #13/#25:
- `listObject[title]` is already the absolute file path, so don’t `path.join(setMainDir(), listObject[title])`.

Validation
- Unit + VS Code integration tests pass locally.