### PR TITLE
v2: Emacs-style tags/planning + migration command

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,23 +1,38 @@
 .vscode/**
 .vscode-test/**
 .git/**
-out/test/**
-out/**/*.map
+node_modules/**
+
+# Build outputs (keep dist/, it's the extension entrypoint)
+**/*.map
+out/**
 src/**
+
+# Repo-only content
+Test Org Files/**
+Test Files/**
+Roadmap/**
+examples/**
+Images/**
+org-vscode/**
+
+# Tooling / docs not needed at runtime
 .gitignore
 tsconfig.json
 vsc-extension-quickstart.md
 tslint.json
-Images/**
-node_modules/**
-org-vscode/out/**
-org-vscode/test/**
-org-vscode/scripts/**
-*.orig
-*.rej
-*.patch
+build.ps1
+merge-to-master.ps1
+last_weeks_meals.txt
 howto.md
 roadmap.md
 TYPESCRIPT
 CONTRIBUTING.md
 manifest.scm
+JIRA integration.txt
+
+# Local patch artifacts / packages
+*.orig
+*.rej
+*.patch
+*.vsix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,23 @@
 # Change Log
 
 # [Unreleased]
-`Enhanced`
+
+# [2.0.0] 12-28-25
+`Enhanced / Breaking`
 
 - **Emacs-style tags + match strings:**
   - Canonical tags are end-of-headline `:TAG1:TAG2:` with outline + `#+FILETAGS` inheritance.
   - Tag filtering supports Emacs match strings like `+A+B`, `A|B`, and `+A-B`.
   - Tag groups via `#+TAGS:` blocks are supported and expanded.
+  - Tag names normalize hyphens to underscores (e.g. `TEST-TAG` → `TEST_TAG`) to keep match strings unambiguous.
 
 - **Emacs-style planning lines (SCHEDULED/DEADLINE):**
   - Canonical planning metadata lives on the indented line directly under the heading.
   - Backward-compatible: legacy inline stamps are still recognized.
+
+- **Explicit v2 migration command:**
+  - Adds **Org-vscode: Migrate File to v2 Format** (no automatic rewrites).
+  - Migrates legacy `[+TAG:...]` blocks, inline planning stamps, and `COMPLETED:` → `CLOSED:`.
 
 - **DONE timestamps use `CLOSED` (Issue #18):**
   - DONE transitions now write `CLOSED: [...]` instead of `COMPLETED: [...]`.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 realDestroyer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Org-vscode
 
-![Version](https://img.shields.io/badge/version-v1.10.9-blue.svg)
+![Version](https://img.shields.io/badge/version-v2.0.0-blue.svg)
 
 > A fast, keyboard-driven Org Mode–style task manager built for Visual Studio Code.
 > Inspired by Emacs Org Mode
@@ -29,6 +29,35 @@ Whether you're an Emacs power user or just want a highly structured task system,
 ---
 
 ## 🧩 Core Features
+
+## 🧭 v2 Format + Migration
+
+Org-vscode v2 follows Emacs Org-mode conventions more closely:
+
+- **Tags** are end-of-headline (Emacs style): `* TODO Title :PROJECT:URGENT:`
+- **Planning metadata** lives on the indented line directly under the heading:
+
+```org
+* TODO Example task :PROJECT:
+	SCHEDULED: [12-29-2025]  DEADLINE: [01-31-2026]
+```
+
+- **DONE timestamps** use `CLOSED:` (legacy `COMPLETED:` is still accepted).
+
+### Migrate a file (explicit, one-time)
+
+Run **Org-vscode: Migrate File to v2 Format**. This converts:
+
+- legacy inline tags like `[+TAG:FOO,BAR]` → `:FOO:BAR:`
+- inline planning stamps on headlines → the planning line below the headline
+- `COMPLETED:` → `CLOSED:`
+
+### Tag naming note (hyphens)
+
+To keep tag match strings unambiguous (where `-TAG` means “NOT TAG”), **tag names normalize hyphens to underscores**:
+
+- typing `test-tag` becomes `TEST_TAG`
+- existing `TEST-TAG` will migrate to `TEST_TAG`
 
 **Task States**  
 `TODO`, `IN_PROGRESS`, `CONTINUED`, `DONE`, `ABANDONED`.

--- a/howto.md
+++ b/howto.md
@@ -46,6 +46,7 @@ VS Code Settings editor (search for `Org-vscode:`):
 ## 📘 Table of Contents <a id="table-of-contents"></a>
 
 * [✅ Multi-line selection editing](#-multi-line-selection-editing)
+* [🧭 v2 Format + Migration](#v2-format--migration)
 * [📁 Change the Main Directory](#change-the-main-directory)
 * [📝 Create a New .org File](#create-a-new-org-file)
 * [🔖 Create a Header](#create-a-header)
@@ -66,6 +67,31 @@ VS Code Settings editor (search for `Org-vscode:`):
 * [📊 Year-In-Review Dashboard](#year-in-review-dashboard)
 
 ---
+
+## 🧭 v2 Format + Migration <a id="v2-format--migration"></a>
+
+Org-vscode v2 aligns more closely with Emacs Org-mode:
+
+- **Tags**: end-of-headline `:TAG1:TAG2:`
+- **Planning** (`SCHEDULED`, `DEADLINE`, `CLOSED`) lives on the indented line directly under the heading
+- **Completion stamp**: `CLOSED:` is canonical (legacy `COMPLETED:` is still accepted)
+
+### Migrate a file to v2 (explicit)
+
+Run **Org-vscode: Migrate File to v2 Format** on a file that still contains legacy constructs like:
+
+- `[+TAG:FOO,BAR]`
+- `SCHEDULED:` / `DEADLINE:` / `CLOSED:` stamps on the headline line
+- `COMPLETED:` timestamps
+
+The migration is designed to be a single-file, explicit, one-time rewrite (no automatic background changes).
+
+### Tag naming note (hyphens)
+
+To keep Emacs-style tag match strings unambiguous (where `-TAG` means “NOT TAG”), tag names normalize hyphens to underscores:
+
+- `test-tag` becomes `TEST_TAG`
+- existing `TEST-TAG` migrates to `TEST_TAG`
 
 ## ✅ Multi-line selection editing
 
@@ -214,7 +240,8 @@ Add deadline dates to tasks to track when they're due. Deadlines appear in the A
 ### Deadline Format
 
 ```org
-* TODO Complete documentation :PROJECT:    SCHEDULED: [12-10-2025]    DEADLINE: [12-15-2025]
+* TODO Complete documentation :PROJECT:
+  SCHEDULED: [12-10-2025]  DEADLINE: [12-15-2025]
 ```
 
 Date formatting is controlled by `Org-vscode.dateFormat` (default: `MM-DD-YYYY`).

--- a/org-vscode/out/alignSchedules.js
+++ b/org-vscode/out/alignSchedules.js
@@ -1,12 +1,12 @@
 const vscode = require("vscode");
-const { isPlanningLine, parsePlanningFromText } = require("./orgTagUtils");
+const { isPlanningLine, parsePlanningFromText, normalizeTagsAfterPlanning } = require("./orgTagUtils");
 
 /**
  * This command aligns all SCHEDULED: timestamps to a fixed column width.
  * It improves readability by right-aligning the timestamps in `.org` files.
  * Also preserves DEADLINE: timestamps that may follow SCHEDULED.
  */
-function alignSchedules() {
+async function alignSchedules() {
     const editor = vscode.window.activeTextEditor;
     if (!editor) {
         vscode.window.showErrorMessage("No active editor detected.");
@@ -17,26 +17,58 @@ function alignSchedules() {
     const totalLines = document.lineCount;
     let maxTaskLength = 0;
     let linesWithScheduled = [];
-    let planningEdits = [];
+    let tagAlignmentCandidates = [];
+    let maxHeadingBaseLength = 0;
+    let normalizedHeadlineEdits = [];
+    let planningNormalizedCount = 0;
 
-    // 🔍 Step 1: Find legacy inline "SCHEDULED:" on heading lines (for column alignment)
-    // and normalize Emacs-style planning lines below headings.
+    // Collect one final replacement per line to avoid overlapping edit ranges.
+    const lineReplacements = new Map();
+
+    const taskPrefixRegex = /^\s*(?:[⊙⊘⊜⊖⊗]\s*)?(?:\*+\s+)?(?:TODO|IN_PROGRESS|CONTINUED|DONE|ABANDONED)\b/;
+
+    // 🔍 Step 1: Find legacy inline "SCHEDULED:" on *headline* lines (for column alignment)
+    // and normalize Emacs-style planning lines below headlines.
     for (let i = 0; i < totalLines; i++) {
         let lineText = document.lineAt(i).text;
 
-        // Capture optional indentation, task text, and the "SCHEDULED:" keyword
-        let match = lineText.match(/^(\s*)(.*?)(\s+SCHEDULED:)/);
+        // Normalize "tags before planning" on headlines so later alignment is consistent.
+        // (We will apply it later via lineReplacements to avoid double-edits.)
+        const normalizedHeadline = normalizeTagsAfterPlanning(lineText);
+        if (normalizedHeadline !== lineText) {
+            normalizedHeadlineEdits.push({ lineNumber: i, newText: normalizedHeadline });
+            lineText = normalizedHeadline;
+        }
 
-        if (match) {
-            let taskLength = match[2].length;
-            maxTaskLength = Math.max(maxTaskLength, taskLength);
+        // Capture optional indentation, task text, and the "SCHEDULED:" keyword.
+        // IMPORTANT: do NOT treat planning lines (indented SCHEDULED/DEADLINE/CLOSED lines)
+        // as legacy inline "SCHEDULED" headlines; doing so drops CLOSED and can create
+        // overlapping edits.
+        if (!isPlanningLine(lineText) && taskPrefixRegex.test(lineText)) {
+            let match = lineText.match(/^(\s*)(.*?)(\s+SCHEDULED:)/);
 
-            // Store only the lines we want to modify later
-            linesWithScheduled.push({ lineNumber: i, indentation: match[1] });
+            if (match) {
+                // Use a consistent measurement with what we later write back.
+                // (Trailing spaces before SCHEDULED: shouldn't affect alignment.)
+                let taskLength = String(match[2] || "").trimEnd().length;
+                maxTaskLength = Math.max(maxTaskLength, taskLength);
+
+                // Store only the headline lines we want to modify later
+                linesWithScheduled.push({ lineNumber: i, indentation: match[1] });
+            }
+        }
+
+        // Track headlines with end-of-line tags so we can align them (Emacs-style).
+        // Example: "* TODO Title :WORK:URGENT:"
+        const tagMatch = lineText.match(/^(\s*.*?)(\s+:(?:[A-Za-z0-9_@#%\-]+:)+)\s*$/);
+        if (tagMatch) {
+            const base = tagMatch[1].replace(/\s+$/g, "");
+            const tags = tagMatch[2].trim();
+            maxHeadingBaseLength = Math.max(maxHeadingBaseLength, base.length);
+            tagAlignmentCandidates.push({ lineNumber: i, base, tags });
         }
 
         // Emacs-style: if this is a task headline, normalize the immediate planning line.
-        const taskPrefixRegex = /^\s*(?:[⊙⊘⊜⊖⊗]\s*)?(?:\*+\s+)?(?:TODO|IN_PROGRESS|CONTINUED|DONE|ABANDONED)\b/;
         if (taskPrefixRegex.test(lineText) && i + 1 < totalLines) {
             const nextLine = document.lineAt(i + 1).text;
             if (isPlanningLine(nextLine) && (nextLine.includes("SCHEDULED:") || nextLine.includes("DEADLINE:") || nextLine.includes("CLOSED:") || nextLine.includes("COMPLETED"))) {
@@ -51,61 +83,87 @@ function alignSchedules() {
                 if (normalized) {
                     const desired = `${planningIndent}${normalized}`;
                     if (desired !== nextLine) {
-                        planningEdits.push({ lineNumber: i + 1, newText: desired });
+                        lineReplacements.set(i + 1, desired);
+                        planningNormalizedCount++;
                     }
                 }
             }
         }
     }
 
+    const hasLegacyInlinePlanning = linesWithScheduled.length > 0;
+    const hasTagCandidates = tagAlignmentCandidates.length > 0;
+    const hasPlanningEdits = planningNormalizedCount > 0;
+    const hasHeadlineNormalizations = normalizedHeadlineEdits.length > 0;
+
     // ✅ Nothing to align/normalize if no entries found
-    if (linesWithScheduled.length === 0 && planningEdits.length === 0) {
-        vscode.window.showWarningMessage("No 'SCHEDULED:' entries found in the file.");
+    if (!hasLegacyInlinePlanning && !hasPlanningEdits && !hasHeadlineNormalizations && !hasTagCandidates) {
+        vscode.window.showWarningMessage("No schedules or tags found to align.");
         return;
     }
 
     // 📏 Step 2: Determine the column to align all *inline* SCHEDULED: timestamps to
     const scheduledColumn = maxTaskLength + 4;
 
-    // ✏️ Step 3: Apply edits
-    editor.edit(editBuilder => {
-        planningEdits.forEach(({ lineNumber, newText }) => {
-            const lineText = document.lineAt(lineNumber).text;
-            const fullRange = new vscode.Range(lineNumber, 0, lineNumber, lineText.length);
+    // 📏 Tag alignment column (when using v2-style end-of-line tags)
+    // Keep this bounded so we don't create huge lines.
+    const tagColumn = Math.min(maxHeadingBaseLength + 2, 80);
+
+    // Step 3a: Compute final per-line replacements.
+    // Lowest precedence: headline normalizations
+    for (const { lineNumber, newText } of normalizedHeadlineEdits) {
+        lineReplacements.set(lineNumber, newText);
+    }
+
+    // Apply legacy inline SCHEDULED alignment (overrides headline normalization on those lines)
+    for (const { lineNumber, indentation } of linesWithScheduled) {
+        const baseLine = lineReplacements.has(lineNumber)
+            ? lineReplacements.get(lineNumber)
+            : document.lineAt(lineNumber).text;
+
+        let match = String(baseLine || "").match(/^(\s*)(.*?)(\s+SCHEDULED:\s*\[\d{2,4}-\d{2}-\d{2,4}\])(\s+DEADLINE:\s*\[\d{2,4}-\d{2}-\d{2,4}(?:\s+\d{2}:\d{2}(?::\d{2})?)?\])?/);
+        if (!match) continue;
+
+        const taskText = match[2].trimEnd();
+        const scheduledText = match[3].trim();
+        const deadlineText = match[4] ? match[4].trim() : "";
+
+        let adjustedLine = indentation + taskText.padEnd(scheduledColumn, " ") + scheduledText;
+        if (deadlineText) {
+            adjustedLine += "    " + deadlineText;
+        }
+
+        lineReplacements.set(lineNumber, adjustedLine);
+    }
+
+    // Apply tag alignment only when there is no legacy inline SCHEDULED alignment to perform.
+    if (!hasLegacyInlinePlanning && hasTagCandidates) {
+        for (const { lineNumber, base, tags } of tagAlignmentCandidates) {
+            const pad = Math.max(1, tagColumn - base.length);
+            const adjusted = `${base}${" ".repeat(pad)}${tags}`;
+            lineReplacements.set(lineNumber, adjusted);
+        }
+    }
+
+    // Step 3b: Apply edits (return a promise so tests/UI can await completion)
+    await editor.edit(editBuilder => {
+        for (const [lineNumber, newText] of lineReplacements.entries()) {
+            const oldText = document.lineAt(lineNumber).text;
+            if (newText === oldText) continue;
+            const fullRange = new vscode.Range(lineNumber, 0, lineNumber, oldText.length);
             editBuilder.replace(fullRange, newText);
-        });
-
-        linesWithScheduled.forEach(({ lineNumber, indentation }) => {
-            const lineText = document.lineAt(lineNumber).text;
-
-            // Full match that includes SCHEDULED timestamp and optional DEADLINE
-            // Pattern: task text + SCHEDULED: [date] + optional DEADLINE: [date]
-            let match = lineText.match(/^(\s*)(.*?)(\s+SCHEDULED:\s*\[\d{2,4}-\d{2}-\d{2,4}\])(\s+DEADLINE:\s*\[\d{2,4}-\d{2}-\d{2,4}(?:\s+\d{2}:\d{2}(?::\d{2})?)?\])?/);
-
-            if (match) {
-                const taskText = match[2].trim();            // Clean up task portion
-                const scheduledText = match[3].trim();       // SCHEDULED:[MM-DD-YYYY]
-                const deadlineText = match[4] ? match[4].trim() : "";  // DEADLINE:[MM-DD-YYYY] if present
-
-                // Pad the task text so all timestamps align to the same column
-                let adjustedLine = indentation + taskText.padEnd(scheduledColumn, " ") + scheduledText;
-                
-                // Append DEADLINE if it was present
-                if (deadlineText) {
-                    adjustedLine += "    " + deadlineText;
-                }
-
-                // Replace the entire original line
-                const fullRange = new vscode.Range(lineNumber, 0, lineNumber, lineText.length);
-                editBuilder.replace(fullRange, adjustedLine);
-            }
-        });
+        }
     });
 
-    const normalizedCount = planningEdits.length;
+    const normalizedCount = planningNormalizedCount;
+    const headlineFixCount = normalizedHeadlineEdits.length;
     const alignedCount = linesWithScheduled.length;
-    console.log(`✅ Updated schedules: ${alignedCount} aligned, ${normalizedCount} planning lines normalized.`);
-    vscode.window.showInformationMessage(`Updated schedules: ${alignedCount} aligned, ${normalizedCount} normalized.`);
+    const tagAlignedCount = (!hasLegacyInlinePlanning && hasTagCandidates) ? tagAlignmentCandidates.length : 0;
+
+    console.log(`✅ Updated alignment: ${alignedCount} inline schedules aligned, ${normalizedCount} planning lines normalized, ${tagAlignedCount} tag lines aligned, ${headlineFixCount} headlines normalized.`);
+    vscode.window.showInformationMessage(
+        `Updated alignment: ${alignedCount} schedules aligned, ${normalizedCount} planning lines normalized, ${tagAlignedCount} tag lines aligned.`
+    );
 }
 
 // Export the command to be used in extension.js

--- a/org-vscode/out/extension.js
+++ b/org-vscode/out/extension.js
@@ -46,6 +46,7 @@ const { generateExecutiveReport } = require("./yearExecutiveReport");
 const { openYearInReview } = require("./yearDashboard");
 const { openSyntaxColorCustomizer } = require("./syntaxColorCustomizer");
 const { registerUnicodeHeadingDecorations } = require("./unicodeHeadingDecorations");
+const { migrateFileToV2 } = require("./migrateFileToV2");
 
 // Startup log for debugging
 console.log("📌 agenda.js has been loaded in extension.js");
@@ -157,6 +158,7 @@ function activate(ctx) {
 
   ctx.subscriptions.push(showMessageCommand);
   ctx.subscriptions.push(vscode.commands.registerCommand("extension.viewAgenda", agenda));
+  ctx.subscriptions.push(vscode.commands.registerCommand("extension.migrateFileToV2", migrateFileToV2));
   // Back-compat: keep existing command id, but steer users to the explicit converter.
   ctx.subscriptions.push(vscode.commands.registerCommand("extension.updateDates", convertDatesInActiveFile));
   ctx.subscriptions.push(vscode.commands.registerCommand("extension.convertDatesInActiveFile", convertDatesInActiveFile));

--- a/org-vscode/out/migrateFileToV2.js
+++ b/org-vscode/out/migrateFileToV2.js
@@ -1,0 +1,234 @@
+"use strict";
+
+const vscode = require("vscode");
+const {
+  getAllTagsFromLine,
+  normalizeTagsAfterPlanning,
+  setEndOfLineTags,
+  isPlanningLine,
+  parsePlanningFromText
+} = require("./orgTagUtils");
+
+const SUPPORTED_LANGUAGE_IDS = new Set(["vso", "org", "vsorg", "org-vscode"]);
+
+function extractPlanningFromLine(text) {
+  const t = String(text || "");
+  const parts = {
+    scheduled: null,
+    deadline: null,
+    closed: null,
+    completed: null
+  };
+
+  const scheduledMatch = t.match(/SCHEDULED:\s*\[([^\]]+)\]/);
+  const deadlineMatch = t.match(/DEADLINE:\s*\[([^\]]+)\]/);
+  const closedMatch = t.match(/CLOSED:\s*\[([^\]]+)\]/);
+  const completedMatch = t.match(/COMPLETED:\s*\[([^\]]+)\]/);
+
+  if (scheduledMatch) parts.scheduled = scheduledMatch[1];
+  if (deadlineMatch) parts.deadline = deadlineMatch[1];
+  if (closedMatch) parts.closed = closedMatch[1];
+  if (completedMatch) parts.completed = completedMatch[1];
+
+  return parts;
+}
+
+function mergePlanning(a, b) {
+  const left = a || {};
+  const right = b || {};
+
+  // Prefer "right" when present (usually the canonical next-line planning).
+  const completed = right.completed || left.completed || null;
+  const closed = right.closed || left.closed || null;
+
+  return {
+    scheduled: right.scheduled || left.scheduled || null,
+    deadline: right.deadline || left.deadline || null,
+    closed: closed || completed || null,
+    completed
+  };
+}
+
+function buildPlanningLine(indent, planning) {
+  const p = planning || {};
+  const segs = [];
+  if (p.scheduled) segs.push(`SCHEDULED: [${p.scheduled}]`);
+  if (p.deadline) segs.push(`DEADLINE: [${p.deadline}]`);
+  if (p.closed) segs.push(`CLOSED: [${p.closed}]`);
+  if (!segs.length) return null;
+  const leading = String(indent || "");
+  const normalizedIndent = leading.length >= 2 ? leading : `${leading}  `;
+  return `${normalizedIndent}${segs.join("  ")}`;
+}
+
+function removeInlinePlanningFromHeadingLine(line) {
+  let out = String(line || "");
+  // Remove planning tokens on the same line as the heading.
+  out = out.replace(/\s+(?:SCHEDULED|DEADLINE|CLOSED|COMPLETED):\s*\[[^\]]*\]/g, "");
+  return out.replace(/\s+$/g, "");
+}
+
+function isHeadingLine(line) {
+  const t = String(line || "");
+  // Headings are either asterisk-based or asterisk-based with optional unicode symbol prefix.
+  // We keep this permissive since users can have either "* TODO" or "⊙ TODO" styles.
+  return /^\s*(?:[⊙⊘⊜⊖⊗]\s*)?\*+\s+/.test(t);
+}
+
+function migrateTextToV2(fileText) {
+  const text = String(fileText || "");
+  const eol = text.includes("\r\n") ? "\r\n" : "\n";
+  const lines = text.split(/\r?\n/);
+
+  const stats = {
+    convertedLegacyTags: 0,
+    movedInlinePlanning: 0,
+    normalizedPlanningLines: 0,
+    convertedCompletedToClosed: 0
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const originalLine = lines[i];
+
+    // 1) Convert legacy COMPLETED -> CLOSED on planning lines anywhere.
+    if (/\bCOMPLETED:\s*\[/.test(originalLine)) {
+      const replaced = originalLine.replace(/\bCOMPLETED:(\s*)\[/g, "CLOSED:$1[");
+      if (replaced !== originalLine) {
+        lines[i] = replaced;
+        stats.convertedCompletedToClosed++;
+      }
+    }
+
+    // 2) Headline migrations: legacy inline tags and inline planning.
+    if (!isHeadingLine(lines[i])) {
+      continue;
+    }
+
+    const currentLine = lines[i];
+    const normalizedForParsing = normalizeTagsAfterPlanning(currentLine);
+
+    const tags = getAllTagsFromLine(normalizedForParsing);
+    const hadLegacyTagBlock = /\[\+TAG:/i.test(normalizedForParsing);
+
+    const planningFromHeadline = extractPlanningFromLine(normalizedForParsing);
+    const hadInlinePlanning = /\b(?:SCHEDULED|DEADLINE|CLOSED|COMPLETED):\s*\[/.test(normalizedForParsing);
+
+    let updatedHeadline = removeInlinePlanningFromHeadingLine(normalizedForParsing);
+    updatedHeadline = setEndOfLineTags(updatedHeadline, tags);
+
+    if (updatedHeadline !== currentLine) {
+      lines[i] = updatedHeadline;
+    }
+
+    if (hadLegacyTagBlock) {
+      stats.convertedLegacyTags++;
+    }
+
+    // Planning: merge headline planning into the next line (planning line) or create one.
+    const nextIndex = i + 1;
+    if (nextIndex >= lines.length) {
+      // Heading is the last line in file; still migrate inline planning by appending a planning line.
+      if (hadInlinePlanning) {
+        const headIndent = (String(lines[i]).match(/^\s*/)?.[0] || "");
+        const planningIndent = `${headIndent}  `;
+        const mergedAtEof = mergePlanning(planningFromHeadline, null);
+        const newPlanningLineAtEof = buildPlanningLine(planningIndent, mergedAtEof);
+        if (newPlanningLineAtEof) {
+          lines.push(newPlanningLineAtEof);
+          stats.movedInlinePlanning++;
+          i++; // skip over the inserted planning line
+        }
+      }
+      continue;
+    }
+
+    const nextLine = lines[nextIndex];
+    const nextLooksLikePlanning = isPlanningLine(nextLine) || /^\s*(?:SCHEDULED|DEADLINE|CLOSED|COMPLETED):\s*\[/.test(String(nextLine || ""));
+
+    const planningFromNext = nextLooksLikePlanning ? parsePlanningFromText(nextLine) : null;
+
+    const merged = mergePlanning(planningFromHeadline, planningFromNext);
+
+    // If we found planning inline on the headline, move it to the planning line.
+    const shouldEnsurePlanningLine = hadInlinePlanning || (nextLooksLikePlanning && /\bCOMPLETED:\s*\[/.test(nextLine));
+
+    if (!shouldEnsurePlanningLine) {
+      continue;
+    }
+
+    // Compute indent: inherit heading indentation, plus two spaces.
+    const headIndent = (String(lines[i]).match(/^\s*/)?.[0] || "");
+    const planningIndent = `${headIndent}  `;
+
+    const newPlanningLine = buildPlanningLine(planningIndent, merged);
+
+    if (newPlanningLine) {
+      if (nextLooksLikePlanning) {
+        if (newPlanningLine !== nextLine) {
+          lines[nextIndex] = newPlanningLine;
+          stats.normalizedPlanningLines++;
+        }
+      } else {
+        lines.splice(nextIndex, 0, newPlanningLine);
+        stats.movedInlinePlanning++;
+        i++; // skip over the inserted planning line
+      }
+    } else if (nextLooksLikePlanning) {
+      // No planning remains after merge; if the next line is only planning content, remove it.
+      const stripped = String(nextLine || "").trim();
+      const onlyPlanning = /^(?:(?:SCHEDULED|DEADLINE|CLOSED|COMPLETED):\s*\[[^\]]*\]\s*)+$/.test(stripped);
+      if (onlyPlanning) {
+        lines.splice(nextIndex, 1);
+        stats.normalizedPlanningLines++;
+      }
+    }
+  }
+
+  const outText = lines.join(eol);
+  return { text: outText, stats };
+}
+
+async function migrateFileToV2() {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    vscode.window.showErrorMessage("No active editor detected.");
+    return;
+  }
+
+  const doc = editor.document;
+  if (!SUPPORTED_LANGUAGE_IDS.has(doc.languageId)) {
+    vscode.window.showErrorMessage(`Unsupported file type for migration: ${doc.languageId}`);
+    return;
+  }
+
+  const originalText = doc.getText();
+  const { text: newText, stats } = migrateTextToV2(originalText);
+
+  if (newText === originalText) {
+    vscode.window.showInformationMessage("No legacy v1 constructs found to migrate.");
+    return;
+  }
+
+  await editor.edit((editBuilder) => {
+    const fullRange = new vscode.Range(doc.positionAt(0), doc.positionAt(originalText.length));
+    editBuilder.replace(fullRange, newText);
+  });
+
+  const changedSummary = [
+    stats.convertedLegacyTags ? `${stats.convertedLegacyTags} tag block(s)` : null,
+    stats.movedInlinePlanning ? `${stats.movedInlinePlanning} planning line(s) inserted` : null,
+    stats.normalizedPlanningLines ? `${stats.normalizedPlanningLines} planning line(s) normalized` : null,
+    stats.convertedCompletedToClosed ? `${stats.convertedCompletedToClosed} COMPLETED→CLOSED` : null
+  ].filter(Boolean).join(", ");
+
+  vscode.window.showInformationMessage(
+    changedSummary
+      ? `Migrated file to v2 format (${changedSummary}).`
+      : "Migrated file to v2 format."
+  );
+}
+
+module.exports = {
+  migrateTextToV2,
+  migrateFileToV2
+};

--- a/org-vscode/out/taggedAgenda.js
+++ b/org-vscode/out/taggedAgenda.js
@@ -78,6 +78,7 @@ async function updateTaskStatusInFile(file, taskText, scheduledDate, newStatus, 
       .replace(/\s+SCHEDULED:.*/, "")
       .replace(/[⊙⊖⊘⊜⊗]/g, "")
       .replace(/^\s*\*+\s+/, "")
+      .replace(/\b(TODO|DONE|IN_PROGRESS|CONTINUED|ABANDONED)\b\s*/g, "")
       .trim();
   }
 
@@ -252,7 +253,7 @@ function showTaggedAgendaView(tag, items) {
       const parts = message.text.split(",");
       const newStatus = parts[0];
       const file = parts[1];
-      const taskText = parts[2].trim();
+      const taskText = (parts[2] || "").replaceAll("&#44;", ",").trim();
       const scheduledDate = parts[3];
       const removeCompleted = message.text.includes("REMOVE_CLOSED") || message.text.includes("REMOVE_COMPLETED");
       console.log("🔄 Changing status:", newStatus, "in file:", file, "for task:", taskText, "with scheduled date:", scheduledDate);
@@ -297,6 +298,7 @@ function getTaggedWebviewContent(webview, nonce, localMomentJs, tag, items) {
         .replace(/\s+SCHEDULED:.*/, "")
         .replace(/[⊙⊖⊘⊜⊗]/g, "")  // Unicode cleanup
         .replace(/^\s*\*+\s+/, "") // Org headline cleanup
+        .replace(/\b(TODO|DONE|IN_PROGRESS|CONTINUED|ABANDONED)\b\s*/g, "") // Keyword cleanup (stable matching)
         .trim();
 
       const lateLabel = scheduledDate && moment(scheduledDate, acceptedDateFormats, true).isBefore(moment(), "day")

--- a/org-vscode/test/suite/commands.test.js
+++ b/org-vscode/test/suite/commands.test.js
@@ -44,4 +44,104 @@ suite('Command registration', function () {
     const missing = uniqueIds.filter(id => !registeredCommands.includes(id));
     assert.deepStrictEqual(missing, [], `Missing keybinding commands: ${missing.join(', ')}`);
   });
+
+  test('Migrate file to v2 rewrites legacy constructs', async () => {
+    const ext = vscode.extensions.getExtension('realDestroyer.org-vscode');
+    assert.ok(ext, 'Extension realDestroyer.org-vscode not found in test host');
+    await ext.activate();
+
+    const input = [
+      '* DONE : [+TAG:Work,proj] - : Example task  SCHEDULED: [2025-01-02]',
+      '  COMPLETED:[2nd January 2025, 9:42:00 am]',
+      '',
+      '* TODO Another task :OldTag:  DEADLINE: [2025-02-03]',
+      '* TODO : [+TAG:TEST-TAG] - Hyphen tag example  SCHEDULED: [2025-03-04]'
+    ].join('\n');
+
+    const doc = await vscode.workspace.openTextDocument({ language: 'vso', content: input });
+    const editor = await vscode.window.showTextDocument(doc);
+
+    await vscode.commands.executeCommand('extension.migrateFileToV2');
+
+    const out = editor.document.getText();
+
+    // Headline tags: legacy [+TAG:...] moved to end-of-headline and normalized.
+    assert.ok(/\* DONE .*:WORK:PROJ:\s*$/.test(out.split(/\r?\n/)[0]), 'Legacy inline tags should become end-of-headline tags');
+
+    // Inline planning moved to planning line under the heading.
+    assert.ok(/\n\s{2,}SCHEDULED: \[2025-01-02\]/.test(out), 'SCHEDULED should be moved to an indented planning line');
+
+    // COMPLETED converted to CLOSED (even when it was already on the planning line).
+    assert.ok(!/\bCOMPLETED:\s*\[/.test(out), 'COMPLETED should not remain after migration');
+    assert.ok(/\bCLOSED:\s*\[2nd January 2025, 9:42:00 am\]/.test(out), 'COMPLETED should migrate to CLOSED');
+
+    // DEADLINE should be moved off the headline into planning line.
+    assert.ok(/\n\s{2,}DEADLINE: \[2025-02-03\]/.test(out), 'DEADLINE should be moved to an indented planning line');
+
+    // Hyphenated tags should not be dropped during migration.
+    assert.ok(/^\* TODO .*:TEST_TAG:\s*$/m.test(out), 'Hyphenated legacy tags should become end-of-headline tags (normalized to underscores)');
+  });
+
+  test('Align Scheduled Tasks auto-aligns legacy inline SCHEDULED columns', async () => {
+    const ext = vscode.extensions.getExtension('realDestroyer.org-vscode');
+    assert.ok(ext, 'Extension realDestroyer.org-vscode not found in test host');
+    await ext.activate();
+
+    const input = [
+      '* TODO Short  SCHEDULED: [2025-01-02]  DEADLINE: [2025-02-03]',
+      '* TODO A much longer headline here  SCHEDULED: [2025-01-02]'
+    ].join('\n');
+
+    const doc = await vscode.workspace.openTextDocument({ language: 'vso', content: input });
+    const editor = await vscode.window.showTextDocument(doc);
+
+    await vscode.commands.executeCommand('extension.alignSchedules');
+
+    const lines = editor.document.getText().split(/\r?\n/);
+    const idx1 = lines[0].indexOf('SCHEDULED:');
+    const idx2 = lines[1].indexOf('SCHEDULED:');
+    assert.ok(idx1 > 0 && idx2 > 0, 'Both lines should contain SCHEDULED after alignment');
+    assert.strictEqual(idx1, idx2, 'SCHEDULED should start at the same column on both lines');
+  });
+
+  test('Align Scheduled Tasks auto-aligns end-of-line tags when no inline SCHEDULED exists', async () => {
+    const ext = vscode.extensions.getExtension('realDestroyer.org-vscode');
+    assert.ok(ext, 'Extension realDestroyer.org-vscode not found in test host');
+    await ext.activate();
+
+    const input = [
+      '* TODO Short :WORK:',
+      '* TODO A much longer headline here :WORK:'
+    ].join('\n');
+
+    const doc = await vscode.workspace.openTextDocument({ language: 'vso', content: input });
+    const editor = await vscode.window.showTextDocument(doc);
+
+    await vscode.commands.executeCommand('extension.alignSchedules');
+
+    const lines = editor.document.getText().split(/\r?\n/);
+    const idx1 = lines[0].indexOf(':WORK:');
+    const idx2 = lines[1].indexOf(':WORK:');
+    assert.ok(idx1 > 0 && idx2 > 0, 'Both lines should contain an aligned tag block');
+    assert.strictEqual(idx1, idx2, 'Tag blocks should start at the same column on both lines');
+  });
+
+  test('Align Scheduled Tasks never drops CLOSED on planning lines', async () => {
+    const ext = vscode.extensions.getExtension('realDestroyer.org-vscode');
+    assert.ok(ext, 'Extension realDestroyer.org-vscode not found in test host');
+    await ext.activate();
+
+    const input = [
+      '* DONE Something important :TEST-TAG:',
+      '  SCHEDULED: [2025-12-17]  DEADLINE: [2026-01-31]  CLOSED: [2025-12-28 Sun 10:49]'
+    ].join('\n');
+
+    const doc = await vscode.workspace.openTextDocument({ language: 'vso', content: input });
+    const editor = await vscode.window.showTextDocument(doc);
+
+    await vscode.commands.executeCommand('extension.alignSchedules');
+
+    const out = editor.document.getText();
+    assert.ok(/\bCLOSED:\s*\[2025-12-28 Sun 10:49\]/.test(out), 'CLOSED should remain on the planning line after alignment');
+  });
 });

--- a/org-vscode/test/suite/tag-match.test.js
+++ b/org-vscode/test/suite/tag-match.test.js
@@ -32,6 +32,16 @@ suite('Tag match-string parsing (Emacs style)', function () {
     assert.strictEqual(matchesTagMatchString('a,b', ['A', 'B']), true);
   });
 
+  test('Hyphenated tag names are normalized to underscores', () => {
+    const { normalizeTag, uniqueUpper, matchesTagMatchString } = require('../../out/orgTagUtils');
+
+    assert.strictEqual(normalizeTag('test-tag'), 'TEST_TAG');
+    assert.deepStrictEqual(uniqueUpper(['test-tag']), ['TEST_TAG']);
+
+    // Tag match strings should use the normalized form.
+    assert.strictEqual(matchesTagMatchString('TEST_TAG', ['TEST-TAG']), true);
+  });
+
   test('Group tags expand to members (#+TAGS: [ GTD : ... ])', () => {
     const { parseTagGroupsFromText, matchesTagMatchString } = require('../../out/orgTagUtils');
 

--- a/org-vscode/vso.tmLanguage.json
+++ b/org-vscode/vso.tmLanguage.json
@@ -91,6 +91,7 @@
       "end": "$",
       "patterns": [
         { "include": "#done" },
+        { "include": "#tag" },
         { "include": "#task_text_done" },
         { "include": "#sched" },
         { "include": "#scheduled" },
@@ -160,6 +161,7 @@
       "begin": "^\\s*[\u2296]",
       "end": "$",
       "patterns": [
+        { "include": "#tag" },
         { "include": "#done" },
         { "include": "#task_text_done" },
         { "include": "#sched" },
@@ -251,7 +253,7 @@
       "patterns": [
         {
           "name": "string.task.todo.vso",
-          "match": "(?<=TODO\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%]+:)+\\s*$)|$)"
+          "match": "(?<=TODO\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)"
         }
       ]
     },
@@ -259,7 +261,7 @@
       "patterns": [
         {
           "name": "string.task.in_progress.vso",
-          "match": "(?<=IN_PROGRESS\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%]+:)+\\s*$)|$)"
+          "match": "(?<=IN_PROGRESS\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)"
         }
       ]
     },
@@ -267,7 +269,7 @@
       "patterns": [
         {
           "name": "string.task.done.vso",
-          "match": "(?<=DONE\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%]+:)+\\s*$)|$)"
+          "match": "(?<=DONE\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)"
         }
       ]
     },
@@ -275,7 +277,7 @@
       "patterns": [
         {
           "name": "string.task.abandoned.vso",
-          "match": "(?<=ABANDONED\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%]+:)+\\s*$)|$)"
+          "match": "(?<=ABANDONED\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)"
         }
       ]
     },
@@ -283,7 +285,7 @@
       "patterns": [
         {
           "name": "string.task.continued.vso",
-          "match": "(?<=CONTINUED\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%]+:)+\\s*$)|$)"
+          "match": "(?<=CONTINUED\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)"
         }
       ]
     },
@@ -314,7 +316,7 @@
     },
     "tag": {
       "patterns": [
-        { "name": "entity.other.attribute-name.tag.vso", "match": "(?:\\[\\+TAG:[^\\]]*\\])|(?:\\s+:(?:[A-Za-z0-9_@#%]+:)+\\s*$)" }
+        { "name": "entity.other.attribute-name.tag.vso", "match": "(?:\\[\\+TAG:[^\\]]*\\])|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)|\\s*$))" }
       ]
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "org-vscode",
-	"version": "1.10.9",
+	"version": "2.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "org-vscode",
-			"version": "1.10.9",
+			"version": "2.0.0",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "org-vscode",
 	"displayName": "org-vscode",
 	"description": "Quickly create todo lists, take notes, plan projects and organize your thoughts.",
-	"version": "1.10.9",
+	"version": "2.0.0",
 	"repository": "https://www.github.com/realDestroyer/org-vscode",
 	"icon": "Logo.png",
 	"publisher": "realDestroyer",
@@ -21,6 +21,7 @@
 		"onLanguage:org-vscode",
 		"onLanguage:vso",
 		"onCommand:extension.viewAgenda",
+		"onCommand:extension.migrateFileToV2",
 		"onCommand:extension.createVsoFile",
 		"onCommand:extension.openSyntaxColorCustomizer",
 		"onCommand:orgMode.exportYearSummary",
@@ -315,6 +316,10 @@
 				"title": "org-vscode Change Org-vscode Directory"
 			},
 			{
+				"command": "extension.migrateFileToV2",
+				"title": "org-vscode: Migrate File to v2 Format"
+			},
+			{
 				"command": "extension.convertDatesInActiveFile",
 				"title": "Org-vscode: Convert Dates in Current File"
 			},
@@ -589,7 +594,8 @@
 		"fetch-media": "node ./org-vscode/scripts/fetch-media.js",
 			"test": "npm run bundle && node ./org-vscode/test/runTest.js",
 			"bundle": "node -e \"require('fs').mkdirSync('dist', { recursive: true })\" && esbuild ./org-vscode/out/extension.js --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --minify",
-		"package": "npm run bundle && node node_modules/.bin/vsce package"
+			"vscode:prepublish": "npm run bundle",
+		"package": "npm run bundle && npx vsce package"
 	},
 	"devDependencies": {
 		"@types/mocha": "^2.2.42",

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,6 +1,6 @@
 ﻿# Roadmap
 
-Live version: 1.10.9
+Live version: 2.0.0
 
 These are the features that I have either already implemented, or plan to in the near future.
 
@@ -8,6 +8,7 @@ These are the features that I have either already implemented, or plan to in the
 
 | Feature Name              | Description                                                                                | Progress    | Version  | Author        |
 | ------------------------- | ------------------------------------------------------------------------------------------ | ----------- | -------- | ------------- |
+| v2 Org-mode Alignment     | Emacs-style end-of-headline tags, FILETAGS inheritance, planning lines under headings, CLOSED stamp, and explicit migration command | DONE | v2.0.0 | realDestroyer |
 | Multi-line Selection Editing | Most editor shortcuts (status, schedule, deadline, tags, headings, date adjusters) apply to all selected task lines | DONE | v1.10.8 | realDestroyer |
 | Keybinding Language-Mode Resilience | Core shortcuts keep working even when `.org` files are not in `vso` language mode | DONE | v1.10.9 | realDestroyer |
 | TODO Notifications        | Notify users of status outside VSCode (email, sms, etc.)                                   | Not Started |          | realDestroyer |

--- a/vso.tmLanguage.json
+++ b/vso.tmLanguage.json
@@ -91,6 +91,7 @@
       "end": "$",
       "patterns": [
         { "include": "#done" },
+        { "include": "#tag" },
         { "include": "#task_text_done" },
         { "include": "#sched" },
         { "include": "#scheduled" },
@@ -160,6 +161,7 @@
       "begin": "^\\s*[\u2296]",
       "end": "$",
       "patterns": [
+        { "include": "#tag" },
         { "include": "#done" },
         { "include": "#task_text_done" },
         { "include": "#sched" },
@@ -251,7 +253,7 @@
       "patterns": [
         {
           "name": "string.task.todo.vso",
-          "match": "(?<=TODO\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%]+:)+\\s*$)|$)"
+          "match": "(?<=TODO\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)"
         }
       ]
     },
@@ -259,7 +261,7 @@
       "patterns": [
         {
           "name": "string.task.in_progress.vso",
-          "match": "(?<=IN_PROGRESS\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%]+:)+\\s*$)|$)"
+          "match": "(?<=IN_PROGRESS\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)"
         }
       ]
     },
@@ -267,7 +269,7 @@
       "patterns": [
         {
           "name": "string.task.done.vso",
-          "match": "(?<=DONE\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%]+:)+\\s*$)|$)"
+          "match": "(?<=DONE\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)"
         }
       ]
     },
@@ -275,7 +277,7 @@
       "patterns": [
         {
           "name": "string.task.abandoned.vso",
-          "match": "(?<=ABANDONED\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%]+:)+\\s*$)|$)"
+          "match": "(?<=ABANDONED\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)"
         }
       ]
     },
@@ -283,7 +285,7 @@
       "patterns": [
         {
           "name": "string.task.continued.vso",
-          "match": "(?<=CONTINUED\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%]+:)+\\s*$)|$)"
+          "match": "(?<=CONTINUED\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)"
         }
       ]
     },
@@ -314,7 +316,7 @@
     },
     "tag": {
       "patterns": [
-        { "name": "entity.other.attribute-name.tag.vso", "match": "(?:\\[\\+TAG:[^\\]]*\\])|(?:\\s+:(?:[A-Za-z0-9_@#%]+:)+\\s*$)" }
+        { "name": "entity.other.attribute-name.tag.vso", "match": "(?:\\[\\+TAG:[^\\]]*\\])|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)|\\s*$))" }
       ]
     }
   }


### PR DESCRIPTION
## Summary
This PR prepares org-vscode v2.0.0 with Emacs Org-mode aligned semantics and explicit migration tooling.

## Key changes
- Tags are canonical end-of-headline `:TAG1:TAG2:` with FILETAGS inheritance + `#+TAGS:` group tags.
- Planning stamps are canonical on the indented planning line under headings (legacy inline stamps still parsed).
- DONE timestamps use `CLOSED:` (legacy `COMPLETED:` still accepted/normalized).
- New command: **Org-vscode: Migrate File to v2 Format** (explicit, one-file rewrite; no automatic background migration).
- `Align Scheduled Tasks` no longer drops `CLOSED:` and avoids overlapping edit ranges.
- Tag naming: hyphens normalize to underscores (e.g. `TEST-TAG` -> `TEST_TAG`) to avoid ambiguity with match string NOT operator (`-TAG`).

## Docs
Updated README/howto/changelog/roadmap for v2 format + migration.

## Testing
- `npm test` (VS Code extension test host): 21 passing.

## Notes
- Backward compatible parsing remains for legacy v1 constructs; migration is opt-in via command.