### PR TITLE
Fix dateFormat across snippets and reports

### DIFF
--- a/org-vscode/out/dateSnippets.js
+++ b/org-vscode/out/dateSnippets.js
@@ -1,0 +1,104 @@
+const vscode = require("vscode");
+const moment = require("moment");
+const { getDateFormat } = require("./dateUtils");
+
+const LANGUAGE_SELECTOR = { language: "vso", scheme: "file" };
+
+function buildTodayString() {
+  const config = vscode.workspace.getConfiguration("Org-vscode");
+  const dateFormat = getDateFormat(config);
+  return moment().format(dateFormat);
+}
+
+function createCompletion(prefix, description, buildSnippet) {
+  const item = new vscode.CompletionItem(prefix, vscode.CompletionItemKind.Snippet);
+  item.detail = "Org-vscode";
+  item.documentation = description;
+  item.insertText = buildSnippet();
+  // Ensure we replace the typed prefix.
+  item.filterText = prefix;
+  item.sortText = `0_${prefix}`;
+  return item;
+}
+
+function registerDateSnippets(ctx) {
+  const provider = {
+    provideCompletionItems(document, position) {
+      const line = document.lineAt(position.line).text;
+
+      // Find the current token (from last whitespace to cursor)
+      const left = line.slice(0, position.character);
+      const match = left.match(/(\S+)$/);
+      const token = match ? match[1] : "";
+      if (!token.startsWith("/")) {
+        return [];
+      }
+
+      const startCol = position.character - token.length;
+      const range = new vscode.Range(
+        new vscode.Position(position.line, startCol),
+        new vscode.Position(position.line, position.character)
+      );
+
+      const today = buildTodayString();
+      const todayDow = moment().format("ddd");
+
+      const items = [];
+
+      const maybePush = (prefix, description, snippetText) => {
+        if (!prefix.startsWith(token)) return;
+        const item = createCompletion(prefix, description, () => new vscode.SnippetString(snippetText));
+        item.range = range;
+        items.push(item);
+      };
+
+      // These are intentionally implemented as completion snippets (not VS Code snippet JSON)
+      // because snippet JSON cannot read extension settings (dateFormat).
+      maybePush(
+        "/day",
+        "New day heading with today's date (uses Org-vscode.dateFormat).",
+        `* [${today} ${todayDow}] -------------------------------------------------------------------------------------------------------------------------------\n    $0`
+      );
+
+      maybePush(
+        "/todo",
+        "New TODO task with scheduled date (uses Org-vscode.dateFormat).",
+        `* TODO \${1:Task}\n   SCHEDULED: [${today}]`
+      );
+
+      maybePush(
+        "/tagged",
+        "Tagged TODO task with scheduled date (uses Org-vscode.dateFormat).",
+        `* TODO \${1:Task} :PROJECT:URGENT:\n   SCHEDULED: [${today}]`
+      );
+
+      maybePush(
+        "/deadline",
+        "Task with scheduled date + deadline (uses Org-vscode.dateFormat).",
+        `* TODO \${1:Task}\n   SCHEDULED: [${today}]\n   DEADLINE: [\${2:${today}}]`
+      );
+
+      maybePush(
+        "/meeting",
+        "Meeting notes header (uses Org-vscode.dateFormat).",
+        `* ${today} :: \${1:Topic}\n- Attendees: \n- Notes:\n- Action Items:\n$0`
+      );
+
+      maybePush(
+        "/template",
+        "Full task template block (uses Org-vscode.dateFormat).",
+        `* TODO \${1:Task Name}\n   SCHEDULED: [${today}]\n   CLOSED: []\n\n- Description:\n- Tags: :TAG:\n\n------------------------\n$0`
+      );
+
+      return items;
+    }
+  };
+
+  ctx.subscriptions.push(
+    vscode.languages.registerCompletionItemProvider(LANGUAGE_SELECTOR, provider, "/")
+  );
+}
+
+module.exports = {
+  registerDateSnippets
+};

--- a/org-vscode/out/dateUtils.js
+++ b/org-vscode/out/dateUtils.js
@@ -1,0 +1,29 @@
+const vscode = require("vscode");
+const moment = require("moment");
+
+function getOrgConfig() {
+  return vscode.workspace.getConfiguration("Org-vscode");
+}
+
+function getDateFormat(config) {
+  const cfg = config || getOrgConfig();
+  return cfg.get("dateFormat", "YYYY-MM-DD");
+}
+
+function getAcceptedDateFormats(config) {
+  const dateFormat = getDateFormat(config);
+  // Always accept the configured format first, but also accept the other supported formats
+  // so features can read older files without forcing conversions.
+  return Array.from(new Set([dateFormat, "YYYY-MM-DD", "MM-DD-YYYY", "DD-MM-YYYY"]));
+}
+
+function parseDateStrict(dateText, config, acceptedFormats) {
+  const formats = acceptedFormats || getAcceptedDateFormats(config);
+  return moment(dateText, formats, true);
+}
+
+module.exports = {
+  getDateFormat,
+  getAcceptedDateFormats,
+  parseDateStrict
+};

--- a/org-vscode/out/extension.js
+++ b/org-vscode/out/extension.js
@@ -51,6 +51,7 @@ const { registerCheckboxAutoDone } = require("./checkboxAutoDone");
 const { registerMarkupCommands } = require("./markupCommands");
 const { registerOrgEmphasisDecorations } = require("./orgEmphasisDecorations");
 const { migrateFileToV2 } = require("./migrateFileToV2");
+const { registerDateSnippets } = require("./dateSnippets");
 
 // Startup log for debugging
 console.log("📌 agenda.js has been loaded in extension.js");
@@ -148,6 +149,10 @@ function activate(ctx) {
 
   // Emacs-style emphasis rendering (bold/italic/underline) + hide markers when not editing them
   registerOrgEmphasisDecorations(ctx);
+
+  // Date-aware snippet expansions that respect Org-vscode.dateFormat.
+  // (VS Code snippet JSON can't read extension settings.)
+  registerDateSnippets(ctx);
 
   // Date format changes are not auto-applied to existing files because swapping
   // MM-DD and DD-MM can be ambiguous (e.g. 04-05-2026). Provide an explicit command instead.

--- a/org-vscode/snippets/vso.json
+++ b/org-vscode/snippets/vso.json
@@ -8,14 +8,6 @@
     ],
     "description": "Section Header"
   },
-  "todo_task": {
-    "prefix": "/todo",
-    "body": [
-      "* TODO $1",
-      "   SCHEDULED: [${CURRENT_DATE}]"
-    ],
-    "description": "New TODO task with scheduled date"
-  },
   "checklist_block": {
     "prefix": "/checklist",
     "body": [
@@ -24,24 +16,6 @@
       "- [ ] "
     ],
     "description": "Checklist block for subtasks"
-  },
-  "meeting_notes": {
-    "prefix": "/meeting",
-    "body": [
-      "* ${CURRENT_DATE} :: $1",
-      "- Attendees: ",
-      "- Notes:",
-      "- Action Items:"
-    ],
-    "description": "Meeting notes or daily log entry"
-  },
-  "tagged_task": {
-    "prefix": "/tagged",
-    "body": [
-      "* TODO $1 :PROJECT:URGENT:",
-      "   SCHEDULED: [${CURRENT_DATE}]"
-    ],
-    "description": "Tagged task template"
   },
   "basic_table_2x2": {
     "prefix": "/table2",
@@ -70,37 +44,6 @@
       "------------------------"
     ],
     "description": "Labeled section block"
-  },
-  "template_block": {
-    "prefix": "/template",
-    "body": [
-      "* TODO Task Name",
-      "   SCHEDULED: [${CURRENT_DATE}]",
-      "   CLOSED: []",
-      "",
-      "- Description:",
-      "- Tags: :TAG:",
-      "",
-      "------------------------"
-    ],
-    "description": "Full task template block"
-  },
-  "day_heading": {
-    "prefix": "/day",
-    "body": [
-      "* [${CURRENT_MONTH}-${CURRENT_DATE}-${CURRENT_YEAR} ${1|Mon,Tue,Wed,Thu,Fri,Sat,Sun|}] -------------------------------------------------------------------------------------------------------------------------------",
-      "    $0"
-    ],
-    "description": "New day heading with today's date and separator"
-  },
-  "deadline_task": {
-    "prefix": "/deadline",
-    "body": [
-      "* TODO $1",
-      "   SCHEDULED: [${CURRENT_MONTH}-${CURRENT_DATE}-${CURRENT_YEAR}]",
-      "   DEADLINE: [$2]"
-    ],
-    "description": "Task with scheduled date and deadline"
   },
   "add_deadline": {
     "prefix": "/dl",

--- a/org-vscode/test/unit/command-registration.test.js
+++ b/org-vscode/test/unit/command-registration.test.js
@@ -29,7 +29,8 @@ function createVscodeMock() {
     },
 
     languages: {
-      registerOnTypeFormattingEditProvider: () => disposable()
+      registerOnTypeFormattingEditProvider: () => disposable(),
+      registerCompletionItemProvider: () => disposable()
     },
 
     window: {

--- a/org-vscode/test/unit/date-format.test.js
+++ b/org-vscode/test/unit/date-format.test.js
@@ -1,0 +1,84 @@
+const assert = require('assert');
+const Module = require('module');
+const path = require('path');
+
+function createVscodeMock(dateFormat) {
+  const disposable = () => ({ dispose() {} });
+
+  return {
+    workspace: {
+      onDidChangeConfiguration: () => disposable(),
+      getConfiguration: () => ({
+        get: (key, fallback) => {
+          if (key === 'dateFormat') return dateFormat;
+          return fallback;
+        }
+      })
+    },
+    window: {
+      showInformationMessage: () => Promise.resolve(undefined),
+      showErrorMessage: () => Promise.resolve(undefined)
+    }
+  };
+}
+
+function withMockedVscode(dateFormat, run) {
+  const vscodeMock = createVscodeMock(dateFormat);
+  const originalLoad = Module._load;
+
+  Module._load = function (request, parent, isMain) {
+    if (request === 'vscode') return vscodeMock;
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  try {
+    return run(vscodeMock);
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+function testReportParsingHonorsConfiguredDateFormat() {
+  // test/unit -> test -> <extension root>
+  const extensionRoot = path.resolve(__dirname, '..', '..');
+  const yearSummaryPath = path.join(extensionRoot, 'out', 'yearSummary.js');
+  const yearReportBuilderPath = path.join(extensionRoot, 'out', 'yearReportBuilder.js');
+
+  return withMockedVscode('DD-MM-YYYY', () => {
+    delete require.cache[require.resolve(yearSummaryPath)];
+    delete require.cache[require.resolve(yearReportBuilderPath)];
+
+    const { parseOrgContent } = require(yearSummaryPath);
+    const { buildDashboardModel } = require(yearReportBuilderPath);
+
+    const org = [
+      '* [31-01-2026 Sat]',
+      '** TODO First task :TAG:',
+      '   SCHEDULED: [31-01-2026]',
+      '* [01-02-2026 Sun]',
+      '** DONE Second task :TAG:',
+      '   SCHEDULED: [01-02-2026]',
+      ''
+    ].join('\n');
+
+    const parsed = parseOrgContent(org);
+    assert.strictEqual(parsed.year, 2026, 'deriveYear should parse DD-MM-YYYY dates');
+
+    const perMonth = parsed.aggregates && parsed.aggregates.perMonth ? parsed.aggregates.perMonth : {};
+    assert.ok(perMonth['2026-01'] >= 1, 'January bucket should exist for DD-MM-YYYY');
+    assert.ok(perMonth['2026-02'] >= 1, 'February bucket should exist for DD-MM-YYYY');
+
+    const dashboard = buildDashboardModel('fake.org', parsed);
+    assert.ok(Array.isArray(dashboard.taskFeed), 'dashboard.taskFeed should exist');
+    assert.ok(dashboard.taskFeed.length >= 1, 'dashboard.taskFeed should include tasks');
+    assert.ok(
+      dashboard.taskFeed.some((t) => t.monthKey === '2026-01' || t.monthKey === '2026-02'),
+      'Tasks should be bucketed into real months, not unscheduled'
+    );
+  });
+}
+
+module.exports = {
+  name: 'unit/date-format',
+  run: testReportParsingHonorsConfiguredDateFormat
+};

--- a/org-vscode/test/unit/run.js
+++ b/org-vscode/test/unit/run.js
@@ -6,7 +6,8 @@
 const path = require('path');
 
 const tests = [
-  require(path.join(__dirname, 'command-registration.test.js'))
+  require(path.join(__dirname, 'command-registration.test.js')),
+  require(path.join(__dirname, 'date-format.test.js'))
 ];
 
 async function main() {


### PR DESCRIPTION
Fixes #41

- Reports: honor Org-vscode.dateFormat when parsing day/scheduled dates (no hardcoded MM-DD-YYYY).
- Snippets: replaces hardcoded /day (and other date-based) JSON snippets with a completion-based snippet provider so expansions respect Org-vscode.dateFormat.
- Tests: adds unit coverage for DD-MM-YYYY parsing + updates command-registration mock.

Notes:
- VS Code snippet JSON can't read extension settings, so date-aware snippets must be implemented via a completion provider.