### PR TITLE
Auto-undone + fix agenda checkbox UI

### DIFF
--- a/org-vscode/out/agenda/agenda.js
+++ b/org-vscode/out/agenda/agenda.js
@@ -973,8 +973,7 @@ module.exports = function () {
                 if (getIndent(inputs[i]) > baseIndent) { hasDesc = true; break; }
               }
 
-              const currentlyChecked = !!input.checked;
-              const desiredChecked = currentlyChecked ? false : true;
+              const desiredChecked = !!input.checked;
 
               const applyState = (el, checked, partial) => {
                 el.checked = !!checked;

--- a/org-vscode/out/checkboxAutoDone.js
+++ b/org-vscode/out/checkboxAutoDone.js
@@ -6,8 +6,8 @@ const moment = require("moment");
 const taskKeywordManager = require("./taskKeywordManager");
 const continuedTaskHandler = require("./continuedTaskHandler");
 const { isPlanningLine, parsePlanningFromText, normalizeTagsAfterPlanning } = require("./orgTagUtils");
+const { computeHeadingTransitions } = require("./checkboxAutoDoneTransitions");
 
-const HEADING_LINE_REGEX = /^(\s*)(\*+|[⊙⊘⊜⊖⊗])\s+\S/;
 const TASK_LINE_REGEX = /^(\s*)(\*+|[⊙⊘⊜⊖⊗])\s+(TODO|IN_PROGRESS|CONTINUED|DONE|ABANDONED)\b/;
 
 const CHECKBOX_REGEX = /^\s*[-+*]\s+\[( |x|X)\]\s+/;
@@ -29,7 +29,7 @@ function buildPlanningBody(planning) {
 }
 
 function isHeadingLine(line) {
-  return HEADING_LINE_REGEX.test(line);
+  return /^\s*(\*+|[⊙⊘⊜⊖⊗])\s+\S/.test(line);
 }
 
 function getHeadingLevel(match) {
@@ -125,6 +125,79 @@ async function applyDoneToHeading(document, lineNumber) {
   await vscode.workspace.applyEdit(workspaceEdit);
 }
 
+async function applyInProgressToHeading(document, lineNumber) {
+  const config = vscode.workspace.getConfiguration("Org-vscode");
+  const headingMarkerStyle = config.get("headingMarkerStyle", "unicode");
+
+  const currentLine = document.lineAt(lineNumber);
+  const nextLine = lineNumber + 1 < document.lineCount ? document.lineAt(lineNumber + 1) : null;
+  const nextNextLine = lineNumber + 2 < document.lineCount ? document.lineAt(lineNumber + 2) : null;
+
+  const keywordMatch = currentLine.text.match(/\b(TODO|IN_PROGRESS|CONTINUED|DONE|ABANDONED)\b/);
+  const currentKeyword = keywordMatch ? keywordMatch[1] : null;
+  if (!currentKeyword) return;
+  if (currentKeyword !== "DONE") return;
+
+  // Never convert day headings like `* [MM-DD-YYYY Wed] ...`.
+  if (continuedTaskHandler.DAY_HEADING_REGEX && continuedTaskHandler.DAY_HEADING_REGEX.test(currentLine.text)) {
+    return;
+  }
+
+  const leadingSpaces = currentLine.text.slice(0, currentLine.firstNonWhitespaceCharacterIndex);
+  const starPrefixMatch = currentLine.text.match(/^\s*(\*+)/);
+  const starPrefix = starPrefixMatch ? starPrefixMatch[1] : "*";
+
+  const planningFromHeadline = parsePlanningFromText(currentLine.text);
+  const planningFromNext = (nextLine && isPlanningLine(nextLine.text)) ? parsePlanningFromText(nextLine.text) : {};
+  const planningFromNextNext = (nextNextLine && isPlanningLine(nextNextLine.text)) ? parsePlanningFromText(nextNextLine.text) : {};
+
+  const mergedPlanning = {
+    scheduled: planningFromNext.scheduled || planningFromHeadline.scheduled || null,
+    deadline: planningFromNext.deadline || planningFromHeadline.deadline || null,
+    closed: planningFromNext.closed || planningFromHeadline.closed || planningFromNextNext.closed || null
+  };
+
+  // Leaving DONE should remove CLOSED.
+  mergedPlanning.closed = null;
+
+  const headlineNoPlanning = stripInlinePlanning(normalizeTagsAfterPlanning(currentLine.text));
+  const cleanedText = taskKeywordManager.cleanTaskText(headlineNoPlanning);
+
+  const nextKeyword = "IN_PROGRESS";
+
+  const workspaceEdit = new vscode.WorkspaceEdit();
+
+  const newLine = taskKeywordManager.buildTaskLine(leadingSpaces, nextKeyword, cleanedText, { headingMarkerStyle, starPrefix });
+  workspaceEdit.replace(document.uri, currentLine.range, newLine);
+
+  const planningIndent = `${leadingSpaces}  `;
+  const planningBody = buildPlanningBody(mergedPlanning);
+
+  if (planningBody) {
+    if (nextLine && isPlanningLine(nextLine.text)) {
+      workspaceEdit.replace(document.uri, nextLine.range, `${planningIndent}${planningBody}`);
+      if (nextNextLine && isPlanningLine(nextNextLine.text)) {
+        workspaceEdit.delete(document.uri, nextNextLine.rangeIncludingLineBreak);
+      }
+    } else {
+      if (nextNextLine && isPlanningLine(nextNextLine.text)) {
+        workspaceEdit.delete(document.uri, nextNextLine.rangeIncludingLineBreak);
+      }
+      workspaceEdit.insert(document.uri, currentLine.range.end, `\n${planningIndent}${planningBody}`);
+    }
+  } else {
+    // Remove planning lines if they exist but will be empty after removing CLOSED.
+    if (nextLine && isPlanningLine(nextLine.text)) {
+      workspaceEdit.delete(document.uri, nextLine.rangeIncludingLineBreak);
+    } else if (nextNextLine && isPlanningLine(nextNextLine.text) && (nextNextLine.text.includes("CLOSED") || nextNextLine.text.includes("COMPLETED"))) {
+      workspaceEdit.delete(document.uri, nextNextLine.rangeIncludingLineBreak);
+    }
+  }
+
+  await vscode.workspace.applyEdit(workspaceEdit);
+}
+
+
 async function autoDoneForDocument(document) {
   if (!document || document.languageId !== "vso") return;
 
@@ -134,64 +207,20 @@ async function autoDoneForDocument(document) {
   const text = document.getText();
   const lines = text.split(/\r?\n/);
 
-  // Collect candidate headings.
-  const candidates = [];
+  const { toMarkDone, toMarkInProgress } = computeHeadingTransitions(lines);
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    const match = line.match(TASK_LINE_REGEX);
-    if (!match) continue;
-
-    const status = match[3];
-    if (status === "DONE" || status === "ABANDONED") continue;
-
-    candidates.push({
-      lineNumber: i,
-      indent: (match[1] || ""),
-      level: getHeadingLevel(match)
-    });
-  }
-
-  if (!candidates.length) return;
-
-  const toMarkDone = [];
-
-  for (const heading of candidates) {
-    let total = 0;
-    let checked = 0;
-
-    for (let j = heading.lineNumber + 1; j < lines.length; j++) {
-      const nextLine = lines[j];
-
-      if (isHeadingLine(nextLine)) {
-        const nextMatch = nextLine.match(TASK_LINE_REGEX) || nextLine.match(HEADING_LINE_REGEX);
-        if (nextMatch) {
-          const nextLevel = getHeadingLevel(nextMatch);
-          if (nextLevel <= heading.level) {
-            break;
-          }
-        }
-      }
-
-      if (isCheckboxLine(nextLine)) {
-        total += 1;
-        if (isCheckboxChecked(nextLine)) checked += 1;
-      }
-    }
-
-    if (total > 0 && checked === total) {
-      toMarkDone.push(heading.lineNumber);
-    }
-  }
-
-  if (!toMarkDone.length) return;
+  if (!toMarkDone.length && !toMarkInProgress.length) return;
 
   // Apply from bottom-up to keep line references stable across inserts.
-  toMarkDone.sort((a, b) => b - a);
+  const ops = [];
+  for (const n of toMarkDone) ops.push({ lineNumber: n, op: "done" });
+  for (const n of toMarkInProgress) ops.push({ lineNumber: n, op: "inprogress" });
+  ops.sort((a, b) => b.lineNumber - a.lineNumber);
 
-  for (const lineNumber of toMarkDone) {
+  for (const o of ops) {
     try {
-      await applyDoneToHeading(document, lineNumber);
+      if (o.op === "done") await applyDoneToHeading(document, o.lineNumber);
+      else await applyInProgressToHeading(document, o.lineNumber);
     } catch (_) {
       // Best-effort: never throw from a background auto-updater.
     }

--- a/org-vscode/out/checkboxAutoDoneTransitions.js
+++ b/org-vscode/out/checkboxAutoDoneTransitions.js
@@ -1,0 +1,98 @@
+"use strict";
+
+const HEADING_LINE_REGEX = /^(\s*)(\*+|[⊙⊘⊜⊖⊗])\s+\S/;
+const TASK_LINE_REGEX = /^(\s*)(\*+|[⊙⊘⊜⊖⊗])\s+(TODO|IN_PROGRESS|CONTINUED|DONE|ABANDONED)\b/;
+const CHECKBOX_REGEX = /^\s*[-+*]\s+\[( |x|X)\]\s+/;
+
+function isHeadingLine(line) {
+  return HEADING_LINE_REGEX.test(String(line || ""));
+}
+
+function getHeadingLevel(match) {
+  const starsOrSymbol = match[2] || "";
+  if (starsOrSymbol.startsWith("*")) {
+    return starsOrSymbol.length;
+  }
+  // For unicode-marker files, use indentation depth as a proxy.
+  const indent = match[1] || "";
+  return 1000 + indent.length;
+}
+
+function isCheckboxLine(line) {
+  return CHECKBOX_REGEX.test(String(line || ""));
+}
+
+function isCheckboxChecked(line) {
+  const m = String(line || "").match(CHECKBOX_REGEX);
+  if (!m) return false;
+  return String(m[1]).toLowerCase() === "x";
+}
+
+function computeHeadingTransitions(lines) {
+  const safeLines = Array.isArray(lines) ? lines : [];
+
+  /** @type {{ lineNumber: number, level: number, status: string }[]} */
+  const candidates = [];
+
+  for (let i = 0; i < safeLines.length; i++) {
+    const line = safeLines[i];
+    const match = String(line || "").match(TASK_LINE_REGEX);
+    if (!match) continue;
+
+    const status = match[3];
+    if (status === "ABANDONED") continue;
+
+    candidates.push({
+      lineNumber: i,
+      level: getHeadingLevel(match),
+      status
+    });
+  }
+
+  /** @type {number[]} */
+  const toMarkDone = [];
+  /** @type {number[]} */
+  const toMarkInProgress = [];
+
+  for (const heading of candidates) {
+    let total = 0;
+    let checked = 0;
+
+    for (let j = heading.lineNumber + 1; j < safeLines.length; j++) {
+      const nextLine = safeLines[j];
+
+      if (isHeadingLine(nextLine)) {
+        const nextMatch = String(nextLine || "").match(TASK_LINE_REGEX) || String(nextLine || "").match(HEADING_LINE_REGEX);
+        if (nextMatch) {
+          const nextLevel = getHeadingLevel(nextMatch);
+          if (nextLevel <= heading.level) {
+            break;
+          }
+        }
+      }
+
+      if (isCheckboxLine(nextLine)) {
+        total += 1;
+        if (isCheckboxChecked(nextLine)) checked += 1;
+      }
+    }
+
+    if (total === 0) continue;
+
+    if (heading.status === "DONE") {
+      if (checked < total) {
+        toMarkInProgress.push(heading.lineNumber);
+      }
+    } else {
+      if (checked === total) {
+        toMarkDone.push(heading.lineNumber);
+      }
+    }
+  }
+
+  return { toMarkDone, toMarkInProgress };
+}
+
+module.exports = {
+  computeHeadingTransitions
+};

--- a/org-vscode/out/taggedAgenda.js
+++ b/org-vscode/out/taggedAgenda.js
@@ -798,8 +798,7 @@ body{
                 if (getIndent(inputs[i]) > baseIndent) { hasDesc = true; break; }
               }
 
-              const currentlyChecked = !!input.checked;
-              const desiredChecked = currentlyChecked ? false : true;
+              const desiredChecked = !!input.checked;
 
               const applyState = (el, checked, partial) => {
                 el.checked = !!checked;

--- a/org-vscode/test/unit/checkbox-auto-done.test.js
+++ b/org-vscode/test/unit/checkbox-auto-done.test.js
@@ -1,0 +1,32 @@
+const assert = require('assert');
+const path = require('path');
+
+const { computeHeadingTransitions } = require(path.join(__dirname, '..', '..', 'out', 'checkboxAutoDoneTransitions.js'));
+
+function testTransitionsMarkDoneAndRevertToInProgress() {
+  const lines = [
+    '* IN_PROGRESS Task A',
+    '  - [X] one',
+    '  - [X] two',
+    '',
+    '* DONE Task B',
+    '  - [X] one',
+    '  - [ ] two',
+    '',
+    '* ABANDONED Task C',
+    '  - [ ] one',
+    '  - [X] two',
+  ];
+
+  const { toMarkDone, toMarkInProgress } = computeHeadingTransitions(lines);
+
+  assert.deepStrictEqual(toMarkDone, [0], 'Expected Task A to be marked DONE');
+  assert.deepStrictEqual(toMarkInProgress, [4], 'Expected Task B to revert to IN_PROGRESS');
+}
+
+module.exports = {
+  name: 'unit/checkbox-auto-done',
+  run: () => {
+    testTransitionsMarkDoneAndRevertToInProgress();
+  }
+};

--- a/org-vscode/test/unit/run.js
+++ b/org-vscode/test/unit/run.js
@@ -9,6 +9,7 @@ const tests = [
   require(path.join(__dirname, 'command-registration.test.js')),
   require(path.join(__dirname, 'checkbox-stats.test.js')),
   require(path.join(__dirname, 'checkbox-cookie-toggle.test.js')),
+  require(path.join(__dirname, 'checkbox-auto-done.test.js')),
   require(path.join(__dirname, 'checkbox-toggle.test.js'))
 ];
 

--- a/package.json
+++ b/package.json
@@ -324,7 +324,7 @@
 					"type": "boolean",
 					"order": 9,
 					"default": false,
-					"description": "Automatically change a task heading to DONE when all checkboxes under it are checked. Works for editor edits and edits written by the agenda view."
+					"description": "When enabled: automatically change a task heading to DONE when all checkboxes under it are checked, and change it back to IN_PROGRESS if any checkbox becomes unchecked. Works for editor edits and edits written by the agenda view."
 				},
 				"Org-vscode.decorateEmphasis": {
 					"type": "boolean",


### PR DESCRIPTION
Closes #43.

- When Org-vscode.autoDoneWhenAllCheckboxesChecked is enabled, headings now revert from DONE to IN_PROGRESS if any checkbox under them becomes unchecked.
- Agenda View and Tagged Agenda details panes now immediately reflect checkbox toggles in the UI (no full refresh needed, so filters/expansions stay open).
- Added unit test for heading transition detection via a new pure helper module.

Tested: 
ode org-vscode/test/unit/run.js, 
pm test.