### PR TITLE
feat: Org-mode statistics cookies + subtree TODO stats

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # [Unreleased]
 
+# [2.1.3] 01-05-26
+`Enhanced`
+
+- **Statistics cookies (Org-mode placeholders):** Cookies now use `[/]` (fraction) and `[%]` (percent) placeholders, which Org-vscode renders as `[n/m]` and `[p%]`.
+- **Subtree completion stats:** Heading cookies include TODO subtree completion in addition to checkbox completion (DONE/ABANDONED count as complete).
+
 # [2.1.2] 01-04-26
 `Fixed / Enhanced`
 

--- a/docs/howto.md
+++ b/docs/howto.md
@@ -237,7 +237,7 @@ The Agenda View shows only **TODO** and **IN_PROGRESS** tasks. Tasks marked as C
 
 ## ☑️ Checkboxes <a id="checkboxes"></a>
 
-Checkbox completion stats are cookie-driven (Emacs-style): add `[n/m]` or `[p%]` to the end of a heading or list item to show stats.
+Checkbox completion stats are cookie-driven (Emacs-style): add `[/]` (fraction) or `[%]` (percent) to the end of a heading or list item to show stats (Org-vscode renders them as `[n/m]` or `[p%]`).
 
 <img src="https://github.com/realdestroyer/org-vscode/blob/master/Images/checkbox-example.png?raw=true" width="900" />
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 ﻿# Roadmap
 
-Live version: 2.1.2
+Live version: 2.1.3
 
 These are the features that I have either already implemented, or plan to in the near future.
 
@@ -13,7 +13,7 @@ These are the features that I have either already implemented, or plan to in the
 | Org-Indent-style indent decoration | When unicode decorations are off, indentation decorations still render with a trailing `*` (Emacs Org-Indent behavior) | DONE | v2.0.2 | realDestroyer |
 | Insert Table (Org pipe output) | Insert Table webview generates canonical Org pipe tables and functions correctly under strict CSP | DONE | v2.0.2 | realDestroyer |
 | Snippets ship in VSIX | Ensure `snippets/vso.json` is included in packaged VSIX so snippet completions work after install | DONE | v2.0.2 | realDestroyer |
-| Checkbox stats + toggling | Emacs-style checkbox cookies (`[n/m]` and `[p%]`), hierarchical counting, clickable agenda details, and editor toggle shortcut | DONE | v2.1.1 | realDestroyer |
+| Checkbox + subtree stats | Org-mode statistics cookies (`[/]` and `[%]`), hierarchical counting, TODO-subtree completion included on heading cookies (DONE/ABANDONED count as complete), clickable agenda details, and editor toggle shortcut | DONE | v2.1.3 | realDestroyer |
 | Multi-line Selection Editing | Most editor shortcuts (status, schedule, deadline, tags, headings, date adjusters) apply to all selected task lines | DONE | v1.10.8 | realDestroyer |
 | Keybinding Language-Mode Resilience | Core shortcuts keep working even when `.org` files are not in `vso` language mode | DONE | v1.10.9 | realDestroyer |
 | TODO Notifications        | Notify users of status outside VSCode (email, sms, etc.)                                   | Not Started |          | realDestroyer |

--- a/org-vscode/out/checkboxStatsDecorations.js
+++ b/org-vscode/out/checkboxStatsDecorations.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const vscode = require("vscode");
-const { computeHierarchicalCheckboxStatsInRange, findCheckboxCookie, formatCheckboxStats } = require("./checkboxStats");
+const { computeHierarchicalCheckboxStatsInRange, computeSubtreeCompletionStatsInRange, findCheckboxCookie, formatCheckboxStats } = require("./checkboxStats");
 
 const HEADING_LINE_REGEX = /^(\s*)(\*+|[⊙⊘⊜⊖⊗])\s+\S/;
 const LIST_ITEM_REGEX = /^\s*[-+*]\s+/;
@@ -105,7 +105,9 @@ function registerCheckboxStatsDecorations(ctx) {
         }
       }
 
-      const stats = computeHierarchicalCheckboxStatsInRange(lines, startLine, endLine, baseIndent);
+      const stats = isHeading
+        ? computeSubtreeCompletionStatsInRange(lines, startLine, endLine)
+        : computeHierarchicalCheckboxStatsInRange(lines, startLine, endLine, baseIndent);
       const formatted = formatCheckboxStats(stats, cookie.mode);
 
       const start = new vscode.Position(i, cookie.start);

--- a/org-vscode/out/toggleCheckboxCookie.js
+++ b/org-vscode/out/toggleCheckboxCookie.js
@@ -26,7 +26,7 @@ function findNearestHeadingLine(document, fromLine) {
 function upsertCheckboxCookieInHeadline(lineText, mode) {
   const s = String(lineText || "");
   const cookie = findCheckboxCookie(s);
-  const placeholder = String(mode || "fraction").toLowerCase() === "percent" ? "[0%]" : "[0/0]";
+  const placeholder = String(mode || "fraction").toLowerCase() === "percent" ? "[%]" : "[/]";
 
   // Respect trailing :TAGS: by inserting before them.
   const tagsMatch = s.match(TRAILING_TAGS_REGEX);
@@ -90,14 +90,14 @@ async function toggleCheckboxCookie() {
 
   if (!cookie) {
     items = [
-      { label: "Insert checkbox cookie: [n/m]", description: "Shows fraction stats on this heading", action: "insert", mode: "fraction" },
-      { label: "Insert checkbox cookie: [p%]", description: "Shows percent stats on this heading", action: "insert", mode: "percent" }
+      { label: "Insert statistics cookie: [/]", description: "Shows fraction stats on this heading", action: "insert", mode: "fraction" },
+      { label: "Insert statistics cookie: [%]", description: "Shows percent stats on this heading", action: "insert", mode: "percent" }
     ];
   } else {
     items = [
       { label: "Remove checkbox cookie", description: "Stops showing checkbox stats on this heading", action: "remove" },
-      { label: "Switch cookie to [n/m]", description: "Fraction style", action: "switch", mode: "fraction" },
-      { label: "Switch cookie to [p%]", description: "Percent style", action: "switch", mode: "percent" }
+      { label: "Switch cookie to [/]", description: "Fraction style", action: "switch", mode: "fraction" },
+      { label: "Switch cookie to [%]", description: "Percent style", action: "switch", mode: "percent" }
     ];
   }
 

--- a/org-vscode/test/unit/checkbox-cookie-toggle.test.js
+++ b/org-vscode/test/unit/checkbox-cookie-toggle.test.js
@@ -10,12 +10,12 @@ function testUpsertCookiePlacementBeforeTags() {
   const line = '* Heading :WORK:HOME:';
   assert.strictEqual(
     upsertCheckboxCookieInHeadline(line, 'fraction'),
-    '* Heading [0/0] :WORK:HOME:'
+    '* Heading [/] :WORK:HOME:'
   );
 
   assert.strictEqual(
     upsertCheckboxCookieInHeadline(line, 'percent'),
-    '* Heading [0%] :WORK:HOME:'
+    '* Heading [%] :WORK:HOME:'
   );
 }
 
@@ -23,7 +23,7 @@ function testReplaceCookieInPlace() {
   const line = '* Heading [2/3] :TAG:';
   assert.strictEqual(
     upsertCheckboxCookieInHeadline(line, 'percent'),
-    '* Heading [0%] :TAG:'
+    '* Heading [%] :TAG:'
   );
 }
 
@@ -39,7 +39,7 @@ function testListItemCookieInsertion() {
   const line = '    - [-] Deliver country loving';
   assert.strictEqual(
     upsertCheckboxCookieInHeadline(line, 'fraction'),
-    '    - [-] Deliver country loving [0/0]'
+    '    - [-] Deliver country loving [/]'
   );
 }
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "org-vscode",
 	"displayName": "org-vscode",
 	"description": "Quickly create todo lists, take notes, plan projects and organize your thoughts.",
-	"version": "2.1.2",
+	"version": "2.1.3",
 	"repository": "https://www.github.com/realDestroyer/org-vscode",
 	"icon": "Logo.png",
 	"publisher": "realDestroyer",


### PR DESCRIPTION
Closes #45\n\n- Statistics cookies now use Org-mode placeholders: [/] (fraction) and [%] (percent)\n- Heading cookies include subtree TODO completion (DONE/ABANDONED count complete) in addition to checkbox completion\n- List-item cookies remain checkbox-only\n- Updates unit tests + docs (howto, changelog, roadmap)\n\nRelease: v2.1.3