### PR TITLE
Release v2.1.4 (Org syntax + navigation helpers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 > A fast, keyboard-driven Org Mode–style task manager built for Visual Studio Code.
 > Inspired by Emacs Org Mode
 
+Org-vscode’s long-term direction is to emulate Emacs Org Mode as closely as practical in VS Code (syntax, navigation, and editing workflows). Some Emacs features are still in progress — see the v2.2 parity checklist below.
+
 ---
 
 ## Summary
@@ -24,6 +26,9 @@ Org-vscode helps you manage tasks, notes, and projects in plain text `.org` file
 - Org-mode statistics cookies: `[/]` (fraction) and `[%]` (percent)
 - Subtree completion stats on headings (TODO subtree completion + checkbox completion)
 - Emphasis rendering for `*bold*`, `/italic/`, `_underline_`, `+strike+`
+- Org-mode syntax highlighting for common constructs: lists, code blocks, links, priorities (`[#A]`), property drawers, directives (`#+...`), and basic math fragments
+- Smart navigation helpers: Document Outline (headings) + clickable Org links (including `[[*heading]]`, `[[id:...]]`, `[[#target]]`, `file:`, `http(s)`, `mailto:`)
+- Org link auto-completion inside `[[...]]` (including workspace-wide `id:` suggestions)
 - Org table generator (command + snippets)
 - Reports/tools: Export Current Tasks, Export Yearly Summary, Executive Report, Year-In-Review Dashboard
 - Customization: Syntax Color Customizer + settings for heading markers / indentation / decorations
@@ -37,6 +42,15 @@ See every feature in one file:
 For the full guide (examples + screenshots), see:
 
 - https://github.com/realDestroyer/org-vscode/blob/master/docs/howto.md
+
+## 🚀 Quick Start (Emacs-inspired)
+
+Most workflows are designed to feel familiar if you use Emacs Org Mode — keyboard-first, selection-aware edits, and “structure-first” navigation.
+
+- Open the Command Palette and run Org-vscode commands (many have default keybindings below).
+- Use `Ctrl+Shift+O` to jump to headings (Outline is powered by the Org heading structure).
+- Use `Ctrl+Click` (Windows/Linux) / `Cmd+Click` (Mac) on `[[links]]` to follow them.
+- Type `[[` (or `[[id:`) to trigger Org link completion.
 
 ## 🔑 Keyboard Shortcuts
 
@@ -67,6 +81,18 @@ Most editing shortcuts support multi-line selection: highlight multiple task lin
 | `Ctrl + Shift + C`   | Open the Calendar View                                 |
 | `Ctrl + Shift + E`   | Export all active (non-DONE) tasks to CurrentTasks.org |
 | `Ctrl + Alt + M`     | Show popup message (GitHub link)                       |
+
+---
+
+## 🎯 Emacs Org-mode Parity (v2.2 goal)
+
+We’re working toward a “parity release” (v2.2) that matches key Org-mode workflows more 1:1.
+
+- Planned: Real-time preview + scroll sync
+- Planned: Org-like context-aware insert (Meta-Return style) for headings/lists/tables/properties
+- Planned: Property management commands (set/update properties, auto-create drawers, unique ID generation)
+- Planned: Smart TAB folding behavior across headings/lists/blocks/properties
+- Planned: Insert link command + richer link editing utilities
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 # [Unreleased]
 
+# [2.1.4] 01-06-26
+`Enhanced`
+
+- **Expanded Org syntax highlighting:** Better highlighting coverage for common Org constructs (blocks, lists, links, priorities, drawers/properties, directives, and basic math fragments).
+- **Navigation:** Document Outline for Org headings + improved Org link handling (including `[[*heading]]`, `[[id:...]]`, and `[[#target]]`).
+- **Link completion:** Auto-complete link targets inside `[[...]]`, including workspace-wide `id:` suggestions.
+- **Docs/examples:** Updated documentation and the shipped example Org file to showcase the new syntax and navigation helpers.
+
 # [2.1.3] 01-05-26
 `Enhanced`
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -36,3 +36,35 @@ Thanks for helping improve org-vscode.
 ## Notes for this repo
 
 - Avoid committing directly to `master` unless you intentionally choose to bypass review (e.g., quick solo maintenance). The default expectation is the PR workflow above.
+
+## Release checklist (maintainers)
+
+This repo bundles the extension into `dist/extension.js`. For a release, ensure the version bump and bundle are done on `master`.
+
+1. **Merge to `master`**
+    - Ensure CI/tests are green.
+
+2. **Bump version**
+    - Update the version in:
+       - `org-vscode/package.json`
+       - `org-vscode/org-vscode/package.json` (dev/test copy)
+
+3. **Bundle + test**
+    - From `org-vscode/`:
+       - `npm run bundle`
+    - From `org-vscode/org-vscode/`:
+       - `npm test`
+
+4. **Package VSIX**
+    - From `org-vscode/`:
+       - `npx vsce package`
+
+5. **Publish to VS Code Marketplace**
+    - Requires a VSCE publisher token configured for `realDestroyer`.
+    - From `org-vscode/`:
+       - `npx vsce publish`
+
+6. **Publish to OpenVSX**
+    - Requires an OpenVSX token (commonly via `OVSX_PAT`).
+    - From `org-vscode/`:
+       - `npx ovsx publish -p $env:OVSX_PAT`

--- a/docs/howto.md
+++ b/docs/howto.md
@@ -61,6 +61,7 @@ VS Code Settings editor (search for `Org-vscode:`):
 * [📝 Create a New .org File](#create-a-new-org-file)
 * [🔖 Create a Header](#create-a-header)
 * [🧩 Org-vscode Snippets](#org-vscode-snippets)
+* [🔎 Org syntax + links](#org-syntax--links)
 * [📂 Open a File by Tags or Titles](#open-a-file-by-tags-or-titles)
 * [📅 Agenda View & Scheduling](#agenda-view--scheduling)
 * [☑️ Checkboxes](#checkboxes)
@@ -177,6 +178,53 @@ Just type the prefix and hit `Tab` to expand the snippet inside a `.org` file.
 ```org
 * TODO Task description
   SCHEDULED: [04-21-2025]
+```
+
+---
+
+## 🔎 Org syntax + links <a id="org-syntax--links"></a>
+
+Org-vscode includes expanded Org-mode syntax highlighting plus navigation helpers for common Org constructs.
+
+### Syntax highlighting (examples)
+
+- Blocks:
+
+```org
+#+BEGIN_SRC javascript
+console.log('hello')
+#+END_SRC
+```
+
+- Inline fragments:
+
+```org
+Inline math: $a^2 + b^2 = c^2$
+Priority: [#A]
+```
+
+- Properties/drawers:
+
+```org
+:PROPERTIES:
+:ID: 01234567-89ab-cdef-0123-456789abcdef
+:CUSTOM_ID: demo-anchor
+:END:
+```
+
+### Link navigation + completion
+
+- Follow `[[links]]` with Ctrl+Click (Windows/Linux) / Cmd+Click (Mac).
+- Type `[[` (or `[[id:`) to get link completions.
+
+Examples:
+
+```org
+[[https://example.com][External link]]
+[[file:./notes.org][Local file]]
+[[*A Heading In This File]]
+[[id:01234567-89ab-cdef-0123-456789abcdef]]
+[[#demo-anchor]]
 ```
 
 #### `/checklist` <a id="checklist"></a>

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 ﻿# Roadmap
 
-Live version: 2.1.3
+Live version: 2.1.4
 
 These are the features that I have either already implemented, or plan to in the near future.
 
@@ -14,6 +14,7 @@ These are the features that I have either already implemented, or plan to in the
 | Insert Table (Org pipe output) | Insert Table webview generates canonical Org pipe tables and functions correctly under strict CSP | DONE | v2.0.2 | realDestroyer |
 | Snippets ship in VSIX | Ensure `snippets/vso.json` is included in packaged VSIX so snippet completions work after install | DONE | v2.0.2 | realDestroyer |
 | Checkbox + subtree stats | Org-mode statistics cookies (`[/]` and `[%]`), hierarchical counting, TODO-subtree completion included on heading cookies (DONE/ABANDONED count as complete), clickable agenda details, and editor toggle shortcut | DONE | v2.1.3 | realDestroyer |
+| Org syntax + navigation helpers | Expanded Org-mode syntax highlighting plus Document Outline, clickable Org links, and `[[...]]` link completion (including workspace `id:` suggestions) | DONE | v2.1.4 | realDestroyer |
 | Multi-line Selection Editing | Most editor shortcuts (status, schedule, deadline, tags, headings, date adjusters) apply to all selected task lines | DONE | v1.10.8 | realDestroyer |
 | Keybinding Language-Mode Resilience | Core shortcuts keep working even when `.org` files are not in `vso` language mode | DONE | v1.10.9 | realDestroyer |
 | TODO Notifications        | Notify users of status outside VSCode (email, sms, etc.)                                   | Not Started |          | realDestroyer |

--- a/examples/demo-walkthrough.org
+++ b/examples/demo-walkthrough.org
@@ -131,3 +131,72 @@
 # - Generate Executive Report
 # - Year-In-Review Dashboard
 * TODO Try the reporting commands from Command Palette :REPORTS:
+
+* [2026-01-12 Mon] Org Syntax Parity (Links / Blocks / Math / Properties) ------------------------
+
+# 19) Priorities (Org-style cookies)
+* TODO [#A] Priority demo (A/B/C) :PRIORITY:
+
+# 20) More emphasis: inline code and verbatim
+* TODO Inline code/verbatim demo :STYLE:
+  Use =inline code= and ~verbatim~ for literal text.
+
+# 21) Attributes / directives (used by exporters and previews)
+#+CAPTION: Example caption (directive)
+#+ATTR_HTML: :width 600
+
+# 22) Links: external, file, heading, id, and internal targets
+* TODO Link navigation demo :LINKS:
+  - Bare URL: https://orgmode.org
+  - Bracket link with description: [[https://orgmode.org][Org manual]]
+  - Mail link: mailto:someone@example.com
+  - File link (relative): [[file:../docs/howto.md][Open the How-To]]
+  - Internal heading link: [[*Tables + Exports][Jump to the tables section]]
+
+  This heading has a global ID and a CUSTOM_ID (anchor-like):
+  :PROPERTIES:
+  :ID: 11111111-2222-3333-4444-555555555555
+  :CUSTOM_ID: demo-custom-id
+  :END:
+
+  - ID link (cross-file capable): [[id:11111111-2222-3333-4444-555555555555][Jump via ID]]
+  - Anchor link (targets / CUSTOM_ID): [[#demo-custom-id][Jump via #anchor]]
+
+  A classic Org target looks like this (link to it with [[#demo-target]]):
+  <<demo-target>>
+
+# 23) Lists: ordered, unordered, and checkboxes
+* TODO List syntax demo :LISTS:
+  - Unordered bullet
+  + Alternate unordered bullet
+  1. Ordered item (1.)
+  2) Ordered item (2))
+  - [ ] Checkbox unchecked
+  - [-] Checkbox partial
+  - [X] Checkbox checked
+
+# 24) Blocks: SRC blocks and other BEGIN/END blocks
+* TODO Block syntax demo :BLOCKS:
+  #+BEGIN_SRC javascript
+  function greet(name) {
+    console.log(`Hello, ${name}`);
+  }
+  greet("Org-vscode");
+  #+END_SRC
+
+  #+BEGIN_QUOTE
+  Quoted block text.
+  #+END_QUOTE
+
+  #+BEGIN_EXAMPLE
+  Example block text (no markup processing).
+  #+END_EXAMPLE
+
+# 25) Math: inline and display fragments
+* TODO Math demo :MATH:
+  Inline math: $E = mc^2$
+
+  Display math:
+  $$
+  \sum_{i=1}^{n} i = \frac{n(n+1)}{2}
+  $$

--- a/org-vscode/out/extension.js
+++ b/org-vscode/out/extension.js
@@ -51,6 +51,9 @@ const { registerCheckboxAutoDone } = require("./checkboxAutoDone");
 const { registerCheckboxStatsDecorations } = require("./checkboxStatsDecorations");
 const { registerMarkupCommands } = require("./markupCommands");
 const { registerOrgEmphasisDecorations } = require("./orgEmphasisDecorations");
+const { registerOrgLinkProvider } = require("./orgLinkProvider");
+const { registerOrgSymbolProvider } = require("./orgSymbolProvider");
+const { registerOrgCompletionProvider } = require("./orgCompletionProvider");
 const { migrateFileToV2 } = require("./migrateFileToV2");
 const { insertCheckboxItem } = require("./insertCheckboxItem");
 const { toggleCheckboxCookie } = require("./toggleCheckboxCookie");
@@ -138,6 +141,11 @@ function numOfSpaces(asterisk) {
 // Extension Activation
 // ─────────────────────────────────────────────────────────────
 function activate(ctx) {
+  // Org-like navigation primitives
+  registerOrgLinkProvider(ctx);
+  registerOrgSymbolProvider(ctx);
+  registerOrgCompletionProvider(ctx);
+
   // Visual-only unicode headings for org-style '*' files (no file rewrites)
   registerUnicodeHeadingDecorations(ctx);
 

--- a/org-vscode/out/orgCompletionProvider.js
+++ b/org-vscode/out/orgCompletionProvider.js
@@ -1,0 +1,222 @@
+"use strict";
+
+const vscode = require("vscode");
+const { parseHeadingLine } = require("./orgSymbolProvider");
+
+const WORKSPACE_ID_CACHE_TTL_MS = 15000;
+const WORKSPACE_MAX_FILES_TO_SCAN = 2000;
+
+let workspaceIdCache = {
+  at: 0,
+  ids: [],
+  inFlight: null
+};
+
+function getSelector() {
+  return [
+    { language: "vso", scheme: "file" },
+    { language: "org", scheme: "file" },
+    { language: "vsorg", scheme: "file" },
+    { language: "org-vscode", scheme: "file" }
+  ];
+}
+
+function findLinkContext(document, position) {
+  const lineText = document.lineAt(position.line).text;
+  const prefix = lineText.slice(0, position.character);
+
+  const linkStart = prefix.lastIndexOf("[[");
+  if (linkStart === -1) return null;
+
+  const fromStart = prefix.slice(linkStart);
+  if (fromStart.includes("]]")) return null;
+
+  const typed = prefix.slice(linkStart + 2);
+  // If we've started a description part, don't offer target completions.
+  if (typed.includes("][")) return null;
+
+  const replaceRange = new vscode.Range(
+    new vscode.Position(position.line, linkStart + 2),
+    position
+  );
+
+  return { typed, replaceRange };
+}
+
+function collectIds(document) {
+  const ids = new Set();
+  for (let i = 0; i < document.lineCount; i++) {
+    const text = document.lineAt(i).text;
+    const m = text.match(/^\s*:ID:\s*(\S+)\s*$/);
+    if (m) ids.add(m[1]);
+  }
+  return Array.from(ids);
+}
+
+async function collectWorkspaceIds() {
+  const now = Date.now();
+  if (now - workspaceIdCache.at < WORKSPACE_ID_CACHE_TTL_MS && Array.isArray(workspaceIdCache.ids)) {
+    return workspaceIdCache.ids;
+  }
+
+  if (workspaceIdCache.inFlight) {
+    return workspaceIdCache.inFlight;
+  }
+
+  workspaceIdCache.inFlight = (async () => {
+    const patterns = "**/*.{org,vsorg,vso}";
+    const exclude = "**/{node_modules,.vscode-test}/**";
+    const files = await vscode.workspace.findFiles(patterns, exclude);
+
+    const ids = new Set();
+    const slice = files.slice(0, WORKSPACE_MAX_FILES_TO_SCAN);
+    for (const uri of slice) {
+      try {
+        const data = await vscode.workspace.fs.readFile(uri);
+        const content = Buffer.from(data).toString("utf8");
+        if (!content.includes(":ID:")) continue;
+
+        const lines = content.split(/\r?\n/);
+        for (let i = 0; i < lines.length; i++) {
+          const m = lines[i].match(/^\s*:ID:\s*(\S+)\s*$/);
+          if (m) ids.add(m[1]);
+        }
+      } catch {
+        // ignore unreadable files
+      }
+    }
+
+    const out = Array.from(ids);
+    workspaceIdCache = { at: Date.now(), ids: out, inFlight: null };
+    return out;
+  })();
+
+  try {
+    return await workspaceIdCache.inFlight;
+  } finally {
+    // inFlight cleared in success path; ensure it's cleared on errors too.
+    workspaceIdCache.inFlight = null;
+  }
+}
+
+function collectCustomIds(document) {
+  const ids = new Set();
+  for (let i = 0; i < document.lineCount; i++) {
+    const text = document.lineAt(i).text;
+    const m = text.match(/^\s*:CUSTOM_ID:\s*(\S+)\s*$/);
+    if (m) ids.add(m[1]);
+  }
+  return Array.from(ids);
+}
+
+function collectAnchors(document) {
+  const anchors = new Set();
+
+  // Targets like <<my-target>>
+  for (let i = 0; i < document.lineCount; i++) {
+    const text = document.lineAt(i).text;
+    const re = /<<([^>\n]+)>>/g;
+    for (let match; (match = re.exec(text)); ) {
+      const name = String(match[1] || "").trim();
+      if (name) anchors.add(name);
+    }
+  }
+
+  // Also consider CUSTOM_IDs as anchor targets.
+  for (const id of collectCustomIds(document)) anchors.add(id);
+
+  return Array.from(anchors);
+}
+
+function collectHeadings(document) {
+  const titles = new Set();
+  for (let i = 0; i < document.lineCount; i++) {
+    const parsed = parseHeadingLine(document.lineAt(i).text);
+    if (!parsed) continue;
+    const title = String(parsed.title || "").trim();
+    if (title) titles.add(title);
+  }
+  return Array.from(titles);
+}
+
+class OrgCompletionItemProvider {
+  async provideCompletionItems(document, position) {
+    try {
+      const ctx = findLinkContext(document, position);
+      if (!ctx) return [];
+
+      const typed = String(ctx.typed || "");
+      const trimmed = typed.trimStart();
+
+      const items = [];
+
+      const addReplaceItem = (label, insertText, kind, detail) => {
+        const item = new vscode.CompletionItem(label, kind);
+        item.detail = detail;
+        item.textEdit = vscode.TextEdit.replace(ctx.replaceRange, insertText);
+        return item;
+      };
+
+      // Always offer the common link prefixes when starting a link.
+      if (trimmed.length === 0 || /^\w{0,4}$/.test(trimmed)) {
+        items.push(
+          addReplaceItem("id:", "id:", vscode.CompletionItemKind.Keyword, "Org link type"),
+          addReplaceItem("*Heading", "*", vscode.CompletionItemKind.Keyword, "Org internal heading link"),
+          addReplaceItem("#anchor", "#", vscode.CompletionItemKind.Keyword, "Org internal target/custom-id link")
+        );
+      }
+
+      if (/^id:/i.test(trimmed) || trimmed === "id" || trimmed === "id:") {
+        const ids = new Set();
+        for (const id of collectIds(document)) ids.add(id);
+        try {
+          for (const id of await collectWorkspaceIds()) ids.add(id);
+        } catch {
+          // ignore workspace failures; still provide in-file IDs
+        }
+
+        for (const id of Array.from(ids)) {
+          items.push(addReplaceItem(`id:${id}`, `id:${id}`, vscode.CompletionItemKind.Reference, "Org :ID: property"));
+        }
+      }
+
+      if (/^\*/.test(trimmed) || trimmed === "*") {
+        for (const title of collectHeadings(document)) {
+          items.push(
+            addReplaceItem(`*${title}`, `*${title}`, vscode.CompletionItemKind.Reference, "Org heading")
+          );
+        }
+      }
+
+      if (/^#/.test(trimmed) || trimmed === "#") {
+        for (const anchor of collectAnchors(document)) {
+          items.push(
+            addReplaceItem(`#${anchor}`, `#${anchor}`, vscode.CompletionItemKind.Reference, "Org target/CUSTOM_ID")
+          );
+        }
+      }
+
+      return items;
+    } catch (e) {
+      console.warn("OrgCompletionItemProvider failed:", e);
+      return [];
+    }
+  }
+}
+
+function registerOrgCompletionProvider(ctx) {
+  // Trigger on '[' so typing the second '[' will offer completions.
+  const triggers = ["[", ":", "*", "#"];
+  ctx.subscriptions.push(
+    vscode.languages.registerCompletionItemProvider(getSelector(), new OrgCompletionItemProvider(), ...triggers)
+  );
+}
+
+module.exports = {
+  OrgCompletionItemProvider,
+  registerOrgCompletionProvider,
+  findLinkContext,
+  collectIds,
+  collectAnchors,
+  collectHeadings
+};

--- a/org-vscode/out/orgLinkProvider.js
+++ b/org-vscode/out/orgLinkProvider.js
@@ -1,0 +1,198 @@
+"use strict";
+
+const vscode = require("vscode");
+const path = require("path");
+
+function parseBracketLink(text) {
+  // Supports: [[link][desc]] and [[link]]
+  const m = String(text || "").match(/^\[\[([^\]\n]+)\](?:\[([^\]\n]*)\])?\]$/);
+  if (!m) return null;
+  return { link: m[1], description: m[2] };
+}
+
+function buildCommandUri(command, args) {
+  const encoded = encodeURIComponent(JSON.stringify(args || {}));
+  return vscode.Uri.parse(`command:${command}?${encoded}`);
+}
+
+function normalizeFileLinkTarget(documentUri, rawTarget) {
+  const stripped = String(rawTarget || "").replace(/^file:/, "");
+  const withoutSearch = stripped.split("::")[0];
+  const decoded = withoutSearch.replace(/^\/+/, "");
+
+  // Absolute paths (Windows drive or UNC) vs relative
+  const isWindowsAbs = /^[A-Za-z]:\\/.test(decoded) || /^[A-Za-z]:\//.test(decoded) || /^\\\\/.test(decoded);
+  if (isWindowsAbs) {
+    return vscode.Uri.file(decoded.replace(/\//g, "\\"));
+  }
+
+  const baseDir = path.dirname(documentUri.fsPath);
+  const joined = path.resolve(baseDir, decoded);
+  return vscode.Uri.file(joined);
+}
+
+function getDocumentLinks(document) {
+  const links = [];
+  const text = document.getText();
+
+  // [[...]] links
+  const bracketRe = /\[\[[^\]\n]+\](?:\[[^\]\n]*\])?\]/g;
+  for (let match; (match = bracketRe.exec(text)); ) {
+    const raw = match[0];
+    const parsed = parseBracketLink(raw);
+    if (!parsed) continue;
+
+    const start = document.positionAt(match.index);
+    const end = document.positionAt(match.index + raw.length);
+    const range = new vscode.Range(start, end);
+
+    const linkTarget = parsed.link.trim();
+    let target;
+
+    if (/^https?:\/\//i.test(linkTarget) || /^mailto:/i.test(linkTarget)) {
+      target = vscode.Uri.parse(linkTarget);
+    } else if (/^file:/i.test(linkTarget)) {
+      target = normalizeFileLinkTarget(document.uri, linkTarget);
+    } else if (/^id:/i.test(linkTarget)) {
+      target = buildCommandUri("org-vscode.followOrgLink", { type: "id", id: linkTarget.slice(3).trim() });
+    } else if (/^\*/.test(linkTarget)) {
+      target = buildCommandUri("org-vscode.followOrgLink", { type: "heading", heading: linkTarget.slice(1).trim() });
+    } else if (/^#/.test(linkTarget)) {
+      target = buildCommandUri("org-vscode.followOrgLink", { type: "anchor", anchor: linkTarget.slice(1).trim() });
+    } else {
+      // Fallback: treat as a file path
+      target = normalizeFileLinkTarget(document.uri, `file:${linkTarget}`);
+    }
+
+    const dl = new vscode.DocumentLink(range, target);
+    dl.tooltip = parsed.description ? `${parsed.description} (${parsed.link})` : parsed.link;
+    links.push(dl);
+  }
+
+  // Bare links
+  const bareRe = /(https?:\/\/\S+|mailto:[^\s>]+)/g;
+  for (let match; (match = bareRe.exec(text)); ) {
+    const raw = match[0];
+    const start = document.positionAt(match.index);
+    const end = document.positionAt(match.index + raw.length);
+    links.push(new vscode.DocumentLink(new vscode.Range(start, end), vscode.Uri.parse(raw)));
+  }
+
+  return links;
+}
+
+async function followOrgLink(args) {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) return;
+
+  const document = editor.document;
+  const payload = args || {};
+
+  if (payload.type === "heading" && payload.heading) {
+    const target = String(payload.heading).trim();
+    for (let i = 0; i < document.lineCount; i++) {
+      const text = document.lineAt(i).text;
+      const star = text.match(/^\s*\*+\s+(.*)$/);
+      if (!star) continue;
+      const title = star[1].replace(/\s+:(?:[A-Za-z0-9_@#%\-]+:)+\s*$/g, "").trim();
+      if (title === target || title.endsWith(` ${target}`)) {
+        const pos = new vscode.Position(i, 0);
+        editor.selection = new vscode.Selection(pos, pos);
+        editor.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.InCenter);
+        return;
+      }
+    }
+    vscode.window.showInformationMessage(`Heading not found: ${target}`);
+    return;
+  }
+
+  if (payload.type === "id" && payload.id) {
+    const id = String(payload.id).trim();
+    const patterns = "**/*.{org,vsorg,vso}";
+    const files = await vscode.workspace.findFiles(patterns, "**/node_modules/**");
+
+    for (const uri of files) {
+      try {
+        const data = await vscode.workspace.fs.readFile(uri);
+        const content = Buffer.from(data).toString("utf8");
+        if (!content.includes(id)) continue;
+
+        const lines = content.split(/\r?\n/);
+        for (let i = 0; i < lines.length; i++) {
+          const m = lines[i].match(/^\s*:ID:\s*(\S+)\s*$/);
+          if (m && m[1] === id) {
+            const doc = await vscode.workspace.openTextDocument(uri);
+            const ed = await vscode.window.showTextDocument(doc);
+            const pos = new vscode.Position(i, 0);
+            ed.selection = new vscode.Selection(pos, pos);
+            ed.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.InCenter);
+            return;
+          }
+        }
+      } catch {
+        // ignore
+      }
+    }
+
+    vscode.window.showInformationMessage(`ID not found in workspace: ${id}`);
+    return;
+  }
+
+  if (payload.type === "anchor" && payload.anchor) {
+    const target = String(payload.anchor).trim();
+    for (let i = 0; i < document.lineCount; i++) {
+      const text = document.lineAt(i).text;
+
+      // Targets like <<my-target>>
+      if (new RegExp(`<<\\s*${escapeForRegExp(target)}\\s*>>`).test(text)) {
+        const pos = new vscode.Position(i, 0);
+        editor.selection = new vscode.Selection(pos, pos);
+        editor.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.InCenter);
+        return;
+      }
+
+      // Properties like :CUSTOM_ID: my-target
+      const m = text.match(/^\s*:CUSTOM_ID:\s*(\S+)\s*$/);
+      if (m && m[1] === target) {
+        const pos = new vscode.Position(i, 0);
+        editor.selection = new vscode.Selection(pos, pos);
+        editor.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.InCenter);
+        return;
+      }
+    }
+
+    vscode.window.showInformationMessage(`Target not found: ${target}`);
+    return;
+  }
+
+  vscode.window.showInformationMessage("Unsupported org link.");
+}
+
+function escapeForRegExp(text) {
+  return String(text).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+class OrgDocumentLinkProvider {
+  provideDocumentLinks(document) {
+    try {
+      return getDocumentLinks(document);
+    } catch (e) {
+      console.warn("OrgDocumentLinkProvider failed:", e);
+      return [];
+    }
+  }
+}
+
+function registerOrgLinkProvider(ctx) {
+  const selector = [{ language: "vso", scheme: "file" }, { language: "org", scheme: "file" }, { language: "vsorg", scheme: "file" }, { language: "org-vscode", scheme: "file" }];
+  ctx.subscriptions.push(vscode.languages.registerDocumentLinkProvider(selector, new OrgDocumentLinkProvider()));
+  ctx.subscriptions.push(vscode.commands.registerCommand("org-vscode.followOrgLink", followOrgLink));
+}
+
+module.exports = {
+  OrgDocumentLinkProvider,
+  registerOrgLinkProvider,
+  parseBracketLink,
+  getDocumentLinks,
+  followOrgLink
+};

--- a/org-vscode/out/orgSymbolProvider.js
+++ b/org-vscode/out/orgSymbolProvider.js
@@ -1,0 +1,110 @@
+"use strict";
+
+const vscode = require("vscode");
+
+const STATUS_WORDS = new Set(["TODO", "IN_PROGRESS", "CONTINUED", "DONE", "ABANDONED"]);
+
+function parseHeadingLine(text) {
+  if (typeof text !== "string") return null;
+
+  // Asterisk headings (Org classic)
+  // Example: "*** TODO [#A] My title :tag1:tag2: SCHEDULED: [...]"
+  const star = text.match(/^\s*(\*+)\s+(.*)$/);
+  if (star) {
+    const level = star[1].length;
+    const rawRest = star[2];
+    const title = extractHeadingTitle(rawRest);
+    return { level, title };
+  }
+
+  // Unicode headings (v2 unicode marker style)
+  // We infer a level from indentation (2 spaces per level by default).
+  const uni = text.match(/^(\s*)([⊙⊘⊖⊜⊗])\s+(.*)$/);
+  if (uni) {
+    const leading = uni[1] || "";
+    const level = Math.floor(leading.length / 2) + 1;
+    const title = extractHeadingTitle(uni[3]);
+    return { level, title };
+  }
+
+  return null;
+}
+
+function extractHeadingTitle(rest) {
+  let out = String(rest || "");
+
+  // Leading TODO keyword
+  const maybeStatus = out.match(/^([A-Z_]+)\b\s+(.*)$/);
+  if (maybeStatus && STATUS_WORDS.has(maybeStatus[1])) {
+    out = maybeStatus[2];
+  }
+
+  // Optional priority cookie
+  out = out.replace(/^\s*\[#([A-Z0-9])\]\s+/, "");
+
+  // Strip trailing planning stamps on heading line
+  out = out.replace(/\s+(?:SCHEDULED|DEADLINE|CLOSED|COMPLETED):\s*\[[^\]]*\]/g, "");
+
+  // Strip trailing tags like :tag1:tag2:
+  out = out.replace(/\s+:(?:[A-Za-z0-9_@#%\-]+:)+\s*$/g, "");
+
+  return out.trim();
+}
+
+function buildSymbolsFromLines(lines, uri) {
+  const root = [];
+  const stack = []; // { level, symbol }
+
+  for (let i = 0; i < lines.length; i++) {
+    const parsed = parseHeadingLine(lines[i]);
+    if (!parsed) continue;
+
+    const level = Math.max(1, parsed.level);
+    const name = parsed.title || "(heading)";
+
+    const lineRange = new vscode.Range(new vscode.Position(i, 0), new vscode.Position(i, lines[i].length));
+    const symbol = new vscode.DocumentSymbol(name, "", vscode.SymbolKind.Namespace, lineRange, lineRange);
+
+    while (stack.length && stack[stack.length - 1].level >= level) {
+      stack.pop();
+    }
+
+    if (stack.length) {
+      stack[stack.length - 1].symbol.children.push(symbol);
+    } else {
+      root.push(symbol);
+    }
+
+    stack.push({ level, symbol });
+  }
+
+  return root;
+}
+
+class OrgDocumentSymbolProvider {
+  provideDocumentSymbols(document) {
+    try {
+      const lines = [];
+      for (let i = 0; i < document.lineCount; i++) {
+        lines.push(document.lineAt(i).text);
+      }
+      return buildSymbolsFromLines(lines, document.uri);
+    } catch (e) {
+      console.warn("OrgDocumentSymbolProvider failed:", e);
+      return [];
+    }
+  }
+}
+
+function registerOrgSymbolProvider(ctx) {
+  const selector = [{ language: "vso", scheme: "file" }, { language: "org", scheme: "file" }, { language: "vsorg", scheme: "file" }, { language: "org-vscode", scheme: "file" }];
+  ctx.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(selector, new OrgDocumentSymbolProvider()));
+}
+
+module.exports = {
+  OrgDocumentSymbolProvider,
+  registerOrgSymbolProvider,
+  parseHeadingLine,
+  extractHeadingTitle,
+  buildSymbolsFromLines
+};

--- a/org-vscode/test/unit/command-registration.test.js
+++ b/org-vscode/test/unit/command-registration.test.js
@@ -29,7 +29,10 @@ function createVscodeMock() {
     },
 
     languages: {
-      registerOnTypeFormattingEditProvider: () => disposable()
+      registerOnTypeFormattingEditProvider: () => disposable(),
+      registerDocumentLinkProvider: () => disposable(),
+      registerDocumentSymbolProvider: () => disposable(),
+      registerCompletionItemProvider: () => disposable()
     },
 
     window: {

--- a/org-vscode/vso.tmLanguage.json
+++ b/org-vscode/vso.tmLanguage.json
@@ -4,6 +4,30 @@
   "scopeName": "source.vso",
   "patterns": [
     {
+      "include": "#org_blocks"
+    },
+    {
+      "include": "#org_tables"
+    },
+    {
+      "include": "#org_lists"
+    },
+    {
+      "include": "#org_links"
+    },
+    {
+      "include": "#org_math"
+    },
+    {
+      "include": "#org_emphasis"
+    },
+    {
+      "include": "#org_priority"
+    },
+    {
+      "include": "#org_comments"
+    },
+    {
       "name": "entity.other.attribute-name.tag.vso",
       "comment": "Inline TAG block",
       "match": "\\[\\+TAG:[^\\]]*\\]"
@@ -212,6 +236,369 @@
     { "include": "#timestamp" }
   ],
   "repository": {
+    "org_comments": {
+      "patterns": [
+        {
+          "name": "comment.line.number-sign.vso",
+          "match": "^\\s*#(?!\\+).*$"
+        }
+      ]
+    },
+    "org_priority": {
+      "patterns": [
+        {
+          "name": "constant.other.priority.vso",
+          "match": "\\[#[A-Z0-9]\\]"
+        }
+      ]
+    },
+    "org_emphasis": {
+      "patterns": [
+        {
+          "name": "markup.bold.vso",
+          "match": "(?<!\\S)\\*[^*\\n]+\\*(?!\\S)"
+        },
+        {
+          "name": "markup.italic.vso",
+          "match": "(?<!\\S)/[^/\\n]+/(?!\\S)"
+        },
+        {
+          "name": "markup.underline.vso",
+          "match": "(?<!\\S)_[^_\\n]+_(?!\\S)"
+        },
+        {
+          "name": "markup.strike.vso",
+          "match": "(?<!\\S)\\+[^+\\n]+\\+(?!\\S)"
+        },
+        {
+          "name": "markup.inline.raw.vso",
+          "match": "(?<!\\S)=[^=\\n]+=(?!\\S)"
+        },
+        {
+          "name": "markup.inline.raw.vso",
+          "match": "(?<!\\S)~[^~\\n]+~(?!\\S)"
+        },
+        {
+          "name": "markup.inline.raw.vso",
+          "comment": "Backtick inline code (non-standard Org, but common in docs)",
+          "match": "`[^`\\n]+`"
+        }
+      ]
+    },
+    "org_math": {
+      "patterns": [
+        {
+          "name": "meta.block.math.vso",
+          "begin": "^\\s*\\$\\$\\s*$",
+          "end": "^\\s*\\$\\$\\s*$",
+          "patterns": [
+            { "include": "#org_emphasis" },
+            { "include": "#org_links" }
+          ]
+        },
+        {
+          "name": "string.other.math.inline.vso",
+          "match": "(?<!\\$)\\$[^\\$\\n]+\\$(?!\\$)"
+        }
+      ]
+    },
+    "org_links": {
+      "patterns": [
+        {
+          "name": "markup.underline.link.vso",
+          "match": "\\[\\[[^\\]\\n]+\\](?:\\[[^\\]\\n]*\\])?\\]"
+        },
+        {
+          "name": "markup.underline.link.vso",
+          "match": "\\bhttps?://\\S+"
+        },
+        {
+          "name": "markup.underline.link.vso",
+          "match": "\\bmailto:[^\\s>]+"
+        },
+        {
+          "name": "markup.underline.link.vso",
+          "match": "\\bfile:[^\\s>]+"
+        }
+      ]
+    },
+    "org_tables": {
+      "patterns": [
+        {
+          "name": "meta.table.vso",
+          "match": "^\\s*\\|.*\\|\\s*$",
+          "captures": {
+            "0": { "name": "meta.table.row.vso" }
+          }
+        }
+      ]
+    },
+    "org_lists": {
+      "patterns": [
+        {
+          "name": "meta.list.unordered.vso",
+          "begin": "^\\s*([-+*])\\s+",
+          "beginCaptures": {
+            "1": { "name": "punctuation.definition.list.vso" }
+          },
+          "end": "$",
+          "patterns": [
+            { "include": "#org_list_checkbox" },
+            { "include": "#org_emphasis" },
+            { "include": "#org_links" }
+          ]
+        },
+        {
+          "name": "meta.list.ordered.vso",
+          "begin": "^\\s*(\\d+)([.)])\\s+",
+          "beginCaptures": {
+            "1": { "name": "constant.numeric.list.vso" },
+            "2": { "name": "punctuation.definition.list.vso" }
+          },
+          "end": "$",
+          "patterns": [
+            { "include": "#org_list_checkbox" },
+            { "include": "#org_emphasis" },
+            { "include": "#org_links" }
+          ]
+        }
+      ]
+    },
+    "org_list_checkbox": {
+      "patterns": [
+        {
+          "name": "constant.character.checkbox.vso",
+          "match": "\\[(?: |X|x|-)\\]"
+        }
+      ]
+    },
+    "org_blocks": {
+      "patterns": [
+        {
+          "name": "meta.block.src.vso",
+          "begin": "^\\s*#\\+BEGIN_SRC\\b.*$",
+          "beginCaptures": { "0": { "name": "keyword.control.block.begin.vso" } },
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "endCaptures": { "0": { "name": "keyword.control.block.end.vso" } },
+          "patterns": [
+            { "include": "#org_src_python" },
+            { "include": "#org_src_javascript" },
+            { "include": "#org_src_typescript" },
+            { "include": "#org_src_json" },
+            { "include": "#org_src_yaml" },
+            { "include": "#org_src_sql" },
+            { "include": "#org_src_shell" },
+            { "include": "#org_src_html" },
+            { "include": "#org_src_css" },
+            { "include": "#org_src_java" },
+            { "include": "#org_src_c" },
+            { "include": "#org_src_cpp" },
+            { "include": "#org_src_rust" },
+            { "include": "#org_src_go" }
+          ]
+        },
+        {
+          "name": "meta.block.quote.vso",
+          "begin": "^\\s*#\\+BEGIN_QUOTE\\s*$",
+          "beginCaptures": { "0": { "name": "keyword.control.block.begin.vso" } },
+          "end": "^\\s*#\\+END_QUOTE\\s*$",
+          "endCaptures": { "0": { "name": "keyword.control.block.end.vso" } },
+          "patterns": [
+            { "include": "#org_emphasis" },
+            { "include": "#org_links" }
+          ]
+        },
+        {
+          "name": "meta.block.example.vso",
+          "begin": "^\\s*#\\+BEGIN_EXAMPLE\\s*$",
+          "beginCaptures": { "0": { "name": "keyword.control.block.begin.vso" } },
+          "end": "^\\s*#\\+END_EXAMPLE\\s*$",
+          "endCaptures": { "0": { "name": "keyword.control.block.end.vso" } }
+        },
+        {
+          "name": "meta.block.verse.vso",
+          "begin": "^\\s*#\\+BEGIN_VERSE\\s*$",
+          "beginCaptures": { "0": { "name": "keyword.control.block.begin.vso" } },
+          "end": "^\\s*#\\+END_VERSE\\s*$",
+          "endCaptures": { "0": { "name": "keyword.control.block.end.vso" } }
+        },
+        {
+          "name": "meta.block.center.vso",
+          "begin": "^\\s*#\\+BEGIN_CENTER\\s*$",
+          "beginCaptures": { "0": { "name": "keyword.control.block.begin.vso" } },
+          "end": "^\\s*#\\+END_CENTER\\s*$",
+          "endCaptures": { "0": { "name": "keyword.control.block.end.vso" } }
+        }
+      ]
+    },
+    "org_src_python": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+python\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "source.python",
+          "patterns": [
+            { "include": "source.python" }
+          ]
+        }
+      ]
+    },
+    "org_src_javascript": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+(?:javascript|js)\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "source.js",
+          "patterns": [
+            { "include": "source.js" }
+          ]
+        }
+      ]
+    },
+    "org_src_typescript": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+(?:typescript|ts)\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "source.ts",
+          "patterns": [
+            { "include": "source.ts" }
+          ]
+        }
+      ]
+    },
+    "org_src_json": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+json\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "source.json",
+          "patterns": [
+            { "include": "source.json" }
+          ]
+        }
+      ]
+    },
+    "org_src_yaml": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+(?:yaml|yml)\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "source.yaml",
+          "patterns": [
+            { "include": "source.yaml" }
+          ]
+        }
+      ]
+    },
+    "org_src_sql": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+sql\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "source.sql",
+          "patterns": [
+            { "include": "source.sql" }
+          ]
+        }
+      ]
+    },
+    "org_src_shell": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+(?:shell|bash|sh)\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "source.shell",
+          "patterns": [
+            { "include": "source.shell" }
+          ]
+        }
+      ]
+    },
+    "org_src_html": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+html\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "text.html.basic",
+          "patterns": [
+            { "include": "text.html.basic" }
+          ]
+        }
+      ]
+    },
+    "org_src_css": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+css\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "source.css",
+          "patterns": [
+            { "include": "source.css" }
+          ]
+        }
+      ]
+    },
+    "org_src_java": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+java\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "source.java",
+          "patterns": [
+            { "include": "source.java" }
+          ]
+        }
+      ]
+    },
+    "org_src_c": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+c\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "source.c",
+          "patterns": [
+            { "include": "source.c" }
+          ]
+        }
+      ]
+    },
+    "org_src_cpp": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+(?:cpp|c\\+\\+)\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "source.cpp",
+          "patterns": [
+            { "include": "source.cpp" }
+          ]
+        }
+      ]
+    },
+    "org_src_rust": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+rust\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "source.rust",
+          "patterns": [
+            { "include": "source.rust" }
+          ]
+        }
+      ]
+    },
+    "org_src_go": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+go\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "source.go",
+          "patterns": [
+            { "include": "source.go" }
+          ]
+        }
+      ]
+    },
     "scheduled": {
       "patterns": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "org-vscode",
-	"version": "2.1.1",
+	"version": "2.1.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "org-vscode",
-			"version": "2.1.1",
+			"version": "2.1.4",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "org-vscode",
 	"displayName": "org-vscode",
 	"description": "Quickly create todo lists, take notes, plan projects and organize your thoughts.",
-	"version": "2.1.3",
+	"version": "2.1.4",
 	"repository": "https://www.github.com/realDestroyer/org-vscode",
 	"icon": "Logo.png",
 	"publisher": "realDestroyer",

--- a/vso.tmLanguage.json
+++ b/vso.tmLanguage.json
@@ -4,6 +4,30 @@
   "scopeName": "source.vso",
   "patterns": [
     {
+      "include": "#org_blocks"
+    },
+    {
+      "include": "#org_tables"
+    },
+    {
+      "include": "#org_lists"
+    },
+    {
+      "include": "#org_links"
+    },
+    {
+      "include": "#org_math"
+    },
+    {
+      "include": "#org_emphasis"
+    },
+    {
+      "include": "#org_priority"
+    },
+    {
+      "include": "#org_comments"
+    },
+    {
       "name": "entity.other.attribute-name.tag.vso",
       "comment": "Inline TAG block",
       "match": "\\[\\+TAG:[^\\]]*\\]"
@@ -212,6 +236,369 @@
     { "include": "#timestamp" }
   ],
   "repository": {
+    "org_comments": {
+      "patterns": [
+        {
+          "name": "comment.line.number-sign.vso",
+          "match": "^\\s*#(?!\\+).*$"
+        }
+      ]
+    },
+    "org_priority": {
+      "patterns": [
+        {
+          "name": "constant.other.priority.vso",
+          "match": "\\[#[A-Z0-9]\\]"
+        }
+      ]
+    },
+    "org_emphasis": {
+      "patterns": [
+        {
+          "name": "markup.bold.vso",
+          "match": "(?<!\\S)\\*[^*\\n]+\\*(?!\\S)"
+        },
+        {
+          "name": "markup.italic.vso",
+          "match": "(?<!\\S)/[^/\\n]+/(?!\\S)"
+        },
+        {
+          "name": "markup.underline.vso",
+          "match": "(?<!\\S)_[^_\\n]+_(?!\\S)"
+        },
+        {
+          "name": "markup.strike.vso",
+          "match": "(?<!\\S)\\+[^+\\n]+\\+(?!\\S)"
+        },
+        {
+          "name": "markup.inline.raw.vso",
+          "match": "(?<!\\S)=[^=\\n]+=(?!\\S)"
+        },
+        {
+          "name": "markup.inline.raw.vso",
+          "match": "(?<!\\S)~[^~\\n]+~(?!\\S)"
+        },
+        {
+          "name": "markup.inline.raw.vso",
+          "comment": "Backtick inline code (non-standard Org, but common in docs)",
+          "match": "`[^`\\n]+`"
+        }
+      ]
+    },
+    "org_math": {
+      "patterns": [
+        {
+          "name": "meta.block.math.vso",
+          "begin": "^\\s*\\$\\$\\s*$",
+          "end": "^\\s*\\$\\$\\s*$",
+          "patterns": [
+            { "include": "#org_emphasis" },
+            { "include": "#org_links" }
+          ]
+        },
+        {
+          "name": "string.other.math.inline.vso",
+          "match": "(?<!\\$)\\$[^\\$\\n]+\\$(?!\\$)"
+        }
+      ]
+    },
+    "org_links": {
+      "patterns": [
+        {
+          "name": "markup.underline.link.vso",
+          "match": "\\[\\[[^\\]\\n]+\\](?:\\[[^\\]\\n]*\\])?\\]"
+        },
+        {
+          "name": "markup.underline.link.vso",
+          "match": "\\bhttps?://\\S+"
+        },
+        {
+          "name": "markup.underline.link.vso",
+          "match": "\\bmailto:[^\\s>]+"
+        },
+        {
+          "name": "markup.underline.link.vso",
+          "match": "\\bfile:[^\\s>]+"
+        }
+      ]
+    },
+    "org_tables": {
+      "patterns": [
+        {
+          "name": "meta.table.vso",
+          "match": "^\\s*\\|.*\\|\\s*$",
+          "captures": {
+            "0": { "name": "meta.table.row.vso" }
+          }
+        }
+      ]
+    },
+    "org_lists": {
+      "patterns": [
+        {
+          "name": "meta.list.unordered.vso",
+          "begin": "^\\s*([-+*])\\s+",
+          "beginCaptures": {
+            "1": { "name": "punctuation.definition.list.vso" }
+          },
+          "end": "$",
+          "patterns": [
+            { "include": "#org_list_checkbox" },
+            { "include": "#org_emphasis" },
+            { "include": "#org_links" }
+          ]
+        },
+        {
+          "name": "meta.list.ordered.vso",
+          "begin": "^\\s*(\\d+)([.)])\\s+",
+          "beginCaptures": {
+            "1": { "name": "constant.numeric.list.vso" },
+            "2": { "name": "punctuation.definition.list.vso" }
+          },
+          "end": "$",
+          "patterns": [
+            { "include": "#org_list_checkbox" },
+            { "include": "#org_emphasis" },
+            { "include": "#org_links" }
+          ]
+        }
+      ]
+    },
+    "org_list_checkbox": {
+      "patterns": [
+        {
+          "name": "constant.character.checkbox.vso",
+          "match": "\\[(?: |X|x|-)\\]"
+        }
+      ]
+    },
+    "org_blocks": {
+      "patterns": [
+        {
+          "name": "meta.block.src.vso",
+          "begin": "^\\s*#\\+BEGIN_SRC\\b.*$",
+          "beginCaptures": { "0": { "name": "keyword.control.block.begin.vso" } },
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "endCaptures": { "0": { "name": "keyword.control.block.end.vso" } },
+          "patterns": [
+            { "include": "#org_src_python" },
+            { "include": "#org_src_javascript" },
+            { "include": "#org_src_typescript" },
+            { "include": "#org_src_json" },
+            { "include": "#org_src_yaml" },
+            { "include": "#org_src_sql" },
+            { "include": "#org_src_shell" },
+            { "include": "#org_src_html" },
+            { "include": "#org_src_css" },
+            { "include": "#org_src_java" },
+            { "include": "#org_src_c" },
+            { "include": "#org_src_cpp" },
+            { "include": "#org_src_rust" },
+            { "include": "#org_src_go" }
+          ]
+        },
+        {
+          "name": "meta.block.quote.vso",
+          "begin": "^\\s*#\\+BEGIN_QUOTE\\s*$",
+          "beginCaptures": { "0": { "name": "keyword.control.block.begin.vso" } },
+          "end": "^\\s*#\\+END_QUOTE\\s*$",
+          "endCaptures": { "0": { "name": "keyword.control.block.end.vso" } },
+          "patterns": [
+            { "include": "#org_emphasis" },
+            { "include": "#org_links" }
+          ]
+        },
+        {
+          "name": "meta.block.example.vso",
+          "begin": "^\\s*#\\+BEGIN_EXAMPLE\\s*$",
+          "beginCaptures": { "0": { "name": "keyword.control.block.begin.vso" } },
+          "end": "^\\s*#\\+END_EXAMPLE\\s*$",
+          "endCaptures": { "0": { "name": "keyword.control.block.end.vso" } }
+        },
+        {
+          "name": "meta.block.verse.vso",
+          "begin": "^\\s*#\\+BEGIN_VERSE\\s*$",
+          "beginCaptures": { "0": { "name": "keyword.control.block.begin.vso" } },
+          "end": "^\\s*#\\+END_VERSE\\s*$",
+          "endCaptures": { "0": { "name": "keyword.control.block.end.vso" } }
+        },
+        {
+          "name": "meta.block.center.vso",
+          "begin": "^\\s*#\\+BEGIN_CENTER\\s*$",
+          "beginCaptures": { "0": { "name": "keyword.control.block.begin.vso" } },
+          "end": "^\\s*#\\+END_CENTER\\s*$",
+          "endCaptures": { "0": { "name": "keyword.control.block.end.vso" } }
+        }
+      ]
+    },
+    "org_src_python": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+python\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "source.python",
+          "patterns": [
+            { "include": "source.python" }
+          ]
+        }
+      ]
+    },
+    "org_src_javascript": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+(?:javascript|js)\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "source.js",
+          "patterns": [
+            { "include": "source.js" }
+          ]
+        }
+      ]
+    },
+    "org_src_typescript": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+(?:typescript|ts)\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "source.ts",
+          "patterns": [
+            { "include": "source.ts" }
+          ]
+        }
+      ]
+    },
+    "org_src_json": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+json\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "source.json",
+          "patterns": [
+            { "include": "source.json" }
+          ]
+        }
+      ]
+    },
+    "org_src_yaml": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+(?:yaml|yml)\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "source.yaml",
+          "patterns": [
+            { "include": "source.yaml" }
+          ]
+        }
+      ]
+    },
+    "org_src_sql": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+sql\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "source.sql",
+          "patterns": [
+            { "include": "source.sql" }
+          ]
+        }
+      ]
+    },
+    "org_src_shell": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+(?:shell|bash|sh)\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "source.shell",
+          "patterns": [
+            { "include": "source.shell" }
+          ]
+        }
+      ]
+    },
+    "org_src_html": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+html\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "text.html.basic",
+          "patterns": [
+            { "include": "text.html.basic" }
+          ]
+        }
+      ]
+    },
+    "org_src_css": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+css\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "source.css",
+          "patterns": [
+            { "include": "source.css" }
+          ]
+        }
+      ]
+    },
+    "org_src_java": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+java\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "source.java",
+          "patterns": [
+            { "include": "source.java" }
+          ]
+        }
+      ]
+    },
+    "org_src_c": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+c\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "source.c",
+          "patterns": [
+            { "include": "source.c" }
+          ]
+        }
+      ]
+    },
+    "org_src_cpp": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+(?:cpp|c\\+\\+)\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "source.cpp",
+          "patterns": [
+            { "include": "source.cpp" }
+          ]
+        }
+      ]
+    },
+    "org_src_rust": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+rust\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "source.rust",
+          "patterns": [
+            { "include": "source.rust" }
+          ]
+        }
+      ]
+    },
+    "org_src_go": {
+      "patterns": [
+        {
+          "begin": "^\\s*#\\+BEGIN_SRC\\s+go\\b.*$",
+          "end": "^\\s*#\\+END_SRC\\s*$",
+          "contentName": "source.go",
+          "patterns": [
+            { "include": "source.go" }
+          ]
+        }
+      ]
+    },
     "scheduled": {
       "patterns": [
         {


### PR DESCRIPTION
## Summary
- Bumps extension version to **v2.1.4**.
- Ships expanded Org-mode syntax highlighting + link navigation/completion helpers (code blocks, lists, links, basic math fragments, drawers/properties).
- Updates docs + example Org file to showcase the new syntax and navigation.

## Related (recently closed)
- #48
- #45
- #43

## Release steps after merge
- Run 
pm run bundle from org-vscode/.
- Run 
pm test from org-vscode/org-vscode/.
- Publish: 
px vsce publish (Marketplace) and 
px ovsx publish -p  (OpenVSX).