### PR TITLE
Release v2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Org-vscode helps you manage tasks, notes, and projects in plain text `.org` file
 - Subtree completion stats on headings (TODO subtree completion + checkbox completion)
 - Emphasis rendering for `*bold*`, `/italic/`, `_underline_`, `+strike+`
 - Org-mode syntax highlighting for common constructs: lists, code blocks, links, priorities (`[#A]`), property drawers, directives (`#+...`), and basic math fragments
+- Live Preview (HTML) with editor → preview scroll sync
+- Math symbol decorations (experimental): renders common LaTeX commands (e.g. `\alpha`) as Unicode glyphs while editing
 - Smart navigation helpers: Document Outline (headings) + clickable Org links (including `[[*heading]]`, `[[id:...]]`, `[[#target]]`, `file:`, `http(s)`, `mailto:`)
 - Org link auto-completion inside `[[...]]` (including workspace-wide `id:` suggestions)
 - Org table generator (command + snippets)
@@ -35,7 +37,6 @@ Org-vscode helps you manage tasks, notes, and projects in plain text `.org` file
 
 See every feature in one file:
 
-- Demo video (MP4): https://github.com/realDestroyer/org-vscode/blob/master/Images/demo-example-file.mp4
 - Demo GIF: https://github.com/realDestroyer/org-vscode/blob/master/Images/demo-example-file.gif
 - Download the example file: https://raw.githubusercontent.com/realDestroyer/org-vscode/master/examples/demo-walkthrough.org
 
@@ -64,6 +65,7 @@ Most editing shortcuts support multi-line selection: highlight multiple task lin
 | `Shift + Alt + ↓`    | Move task block down                                   |
 | `Alt + →`            | Increase heading level (selection-aware)               |
 | `Alt + ←`            | Decrease heading level (selection-aware)               |
+| `Alt + Enter`        | Smart insert new element (Org Meta-Return style)       |
 | `Ctrl + Shift + [`   | Fold section                                           |
 | `Ctrl + Shift + ]`   | Unfold section                                         |
 | `Ctrl + Alt + S`     | Schedule a task (selection-aware)                      |
@@ -79,6 +81,7 @@ Most editing shortcuts support multi-line selection: highlight multiple task lin
 | *(Command Palette)*  | Org-vscode: Convert Dates in Current File              |
 | `Ctrl + Shift + G`   | Open the Tagged Agenda View                            |
 | `Ctrl + Shift + C`   | Open the Calendar View                                 |
+| `Ctrl + Alt + P`     | Open Live Preview to the side                          |
 | `Ctrl + Shift + E`   | Export all active (non-DONE) tasks to CurrentTasks.org |
 | `Ctrl + Alt + M`     | Show popup message (GitHub link)                       |
 
@@ -89,7 +92,9 @@ Most editing shortcuts support multi-line selection: highlight multiple task lin
 We’re working toward a “parity release” (v2.2) that matches key Org-mode workflows more 1:1.
 
 - Planned: Real-time preview + scroll sync
-- Planned: Org-like context-aware insert (Meta-Return style) for headings/lists/tables/properties
+- Real-time preview + scroll sync (MVP)
+- Org-like context-aware insert (Meta-Return style): `Alt+Enter` inserts a new heading / list item / table row depending on context
+- Planned: LaTeX fragment rendering (inline "image" preview, org-fragtog-style)
 - Planned: Property management commands (set/update properties, auto-create drawers, unique ID generation)
 - Planned: Smart TAB folding behavior across headings/lists/blocks/properties
 - Planned: Insert link command + richer link editing utilities

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 # [Unreleased]
 
+# [2.2.0] 01-06-26
+`Added / Enhanced`
+
+- **Preview (MVP):** Live HTML preview with editor → preview scroll sync. Commands: `Org-vscode: Open Preview` and `Org-vscode: Open Preview To Side`.
+- **Keybinding:** `Ctrl+Alt+P` opens preview to the side.
+- **Editing (Org Meta-Return style):** `Alt+Enter` smart-inserts a new heading / list item / table row depending on context.
+- **Math (experimental):** Optional math symbol decorations that render common LaTeX commands as Unicode glyphs inside `$...$` and `$$...$$` (setting: `Org-vscode.decorateMath`).
+
 # [2.1.5] 01-06-26
 `Fixed / Enhanced`
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -44,27 +44,34 @@ This repo bundles the extension into `dist/extension.js`. For a release, ensure 
 1. **Merge to `master`**
     - Ensure CI/tests are green.
 
-2. **Bump version**
+2. **Update docs**
+   - Ensure user-facing docs reflect changes:
+      - `README.md`
+      - `docs/CHANGELOG.md`
+      - `docs/howto.md` / `docs/roadmap.md` (as needed)
+
+3. **Bump version**
     - Update the version in:
        - `org-vscode/package.json`
        - `org-vscode/org-vscode/package.json` (dev/test copy)
 
-3. **Bundle + test**
+4. **Bundle + test**
     - From `org-vscode/`:
        - `npm run bundle`
-    - From `org-vscode/org-vscode/`:
-       - `npm test`
+   - From `org-vscode/org-vscode/` (dev/test copy):
+      - `npm run test:unit`
+      - `npm test`
 
-4. **Package VSIX**
+5. **Package VSIX**
     - From `org-vscode/`:
        - `npx vsce package`
 
-5. **Publish to VS Code Marketplace**
+6. **Publish to VS Code Marketplace**
     - Requires a VSCE publisher token configured for `realDestroyer`.
     - From `org-vscode/`:
        - `npx vsce publish`
 
-6. **Publish to OpenVSX**
+7. **Publish to OpenVSX**
     - Requires an OpenVSX token (commonly via `OVSX_PAT`).
     - From `org-vscode/`:
        - `npx ovsx publish -p $env:OVSX_PAT`

--- a/docs/howto.md
+++ b/docs/howto.md
@@ -62,6 +62,8 @@ VS Code Settings editor (search for `Org-vscode:`):
 * [🔖 Create a Header](#create-a-header)
 * [🧩 Org-vscode Snippets](#org-vscode-snippets)
 * [🔎 Org syntax + links](#org-syntax--links)
+* [🪟 Preview (Live HTML)](#preview-live-html)
+* [∑ Math Symbol Decorations](#math-symbol-decorations)
 * [📂 Open a File by Tags or Titles](#open-a-file-by-tags-or-titles)
 * [📅 Agenda View & Scheduling](#agenda-view--scheduling)
 * [☑️ Checkboxes](#checkboxes)
@@ -258,6 +260,42 @@ Examples:
 ```
 
 Snippets make it easy to maintain formatting consistency and move quickly through repetitive structures!
+
+---
+
+## 🪟 Preview (Live HTML) <a id="preview-live-html"></a>
+
+Org-vscode includes a lightweight Live Preview (webview) so you can read your Org file as rendered HTML while you edit.
+
+- Open preview to the side: `Ctrl + Alt + P`
+- Or use the Command Palette:
+  - **Org-vscode: Open Preview**
+  - **Org-vscode: Open Preview To Side**
+
+Notes:
+
+- Preview updates automatically as you type.
+- Scroll sync (editor → preview) is supported.
+
+---
+
+## ∑ Math Symbol Decorations <a id="math-symbol-decorations"></a>
+
+Inside math fragments (e.g. `$...$` or `$$...$$`), Org-vscode can optionally render common LaTeX commands as Unicode symbols while editing.
+
+Example:
+
+```org
+Inline: $\alpha + \beta = \gamma$ and $a \leq b$.
+```
+
+Toggle the feature:
+
+```json
+"Org-vscode.decorateMath": true
+```
+
+This is intentionally lightweight (not a full LaTeX renderer). For org-fragtog-style “fragment images”, see the roadmap.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 ﻿# Roadmap
 
-Live version: 2.1.5
+Live version: 2.2.0
 
 These are the features that I have either already implemented, or plan to in the near future.
 
@@ -16,6 +16,10 @@ These are the features that I have either already implemented, or plan to in the
 | Checkbox + subtree stats | Org-mode statistics cookies (`[/]` and `[%]`), hierarchical counting, TODO-subtree completion included on heading cookies (DONE/ABANDONED count as complete), clickable agenda details, and editor toggle shortcut | DONE | v2.1.3 | realDestroyer |
 | Org syntax + navigation helpers | Expanded Org-mode syntax highlighting plus Document Outline, clickable Org links, and `[[...]]` link completion (including workspace `id:` suggestions) | DONE | v2.1.4 | realDestroyer |
 | Syntax scopes + customizer expansion | Fix task-state scope application for Unicode markers + expand Syntax Color Customizer to cover new Org syntax scopes | DONE | v2.1.5 | realDestroyer |
+| Preview (Live HTML) + scroll sync | Webview-based live preview with automatic refresh and editor → preview scroll sync | In Progress | v2.2.0 | realDestroyer |
+| Org Meta-Return insert | `Alt+Enter` context-aware insert of heading / list item / table row | In Progress | v2.2.0 | realDestroyer |
+| Math symbol decorations | Render common LaTeX commands (e.g. `\alpha`) as Unicode glyphs inside `$...$` / `$$...$$` | In Progress | v2.2.0 | realDestroyer |
+| LaTeX fragment rendering (org-fragtog-style) | Render LaTeX fragments as “inline images” (full math fragment preview, not only symbol substitutions) | Not Started |  | realDestroyer |
 | Multi-line Selection Editing | Most editor shortcuts (status, schedule, deadline, tags, headings, date adjusters) apply to all selected task lines | DONE | v1.10.8 | realDestroyer |
 | Keybinding Language-Mode Resilience | Core shortcuts keep working even when `.org` files are not in `vso` language mode | DONE | v1.10.9 | realDestroyer |
 | TODO Notifications        | Notify users of status outside VSCode (email, sms, etc.)                                   | Not Started |          | realDestroyer |

--- a/examples/demo-walkthrough.org
+++ b/examples/demo-walkthrough.org
@@ -117,6 +117,16 @@
 * TODO Publish to both marketplaces :RELEASE:DEMO:
   SCHEDULED: [2026-01-10]
 
+* [2026-01-10 Sat] Preview (Live HTML) -----------------------------------------------------------
+
+# 16b) Live preview (MVP) + scroll sync
+# Use Ctrl+Alt+P to open preview to the side.
+# Then scroll the editor: the preview should follow.
+* TODO Open the Org Preview :PREVIEW:
+  Tip: Command Palette also has:
+  - Org-vscode: Open Preview
+  - Org-vscode: Open Preview to Side
+
 * [2026-01-11 Sun] Tables + Exports -------------------------------------------------------------
 
 # 17) Insert Org Table command / snippet
@@ -166,7 +176,7 @@
   <<demo-target>>
 
 # 23) Lists: ordered, unordered, and checkboxes
-* TODO List syntax demo :LISTS:
+* IN_PROGRESS List syntax demo :LISTS:
   - Unordered bullet
   + Alternate unordered bullet
   1. Ordered item (1.)
@@ -196,7 +206,17 @@
 * TODO Math demo :MATH:
   Inline math: $E = mc^2$
 
+  # 25a) Math symbol rendering (decorations)
+  # LaTeX commands like \alpha and \sum should render as symbols in the editor.
+  Inline with commands: $\alpha + \beta = \gamma$
+  Operators: $a \leq b \Rightarrow a \neq b$
+
+  
   Display math:
   $$
   \sum_{i=1}^{n} i = \frac{n(n+1)}{2}
+  \int_0^1 x^2\,dx = \frac{1}{3}
   $$
+
+  # If you want to see the raw commands instead of symbols, set:
+  #   Org-vscode.decorateMath = false

--- a/org-vscode/out/extension.js
+++ b/org-vscode/out/extension.js
@@ -51,13 +51,16 @@ const { registerCheckboxAutoDone } = require("./checkboxAutoDone");
 const { registerCheckboxStatsDecorations } = require("./checkboxStatsDecorations");
 const { registerMarkupCommands } = require("./markupCommands");
 const { registerOrgEmphasisDecorations } = require("./orgEmphasisDecorations");
+const { registerMathDecorations } = require("./mathDecorations");
 const { registerOrgLinkProvider } = require("./orgLinkProvider");
 const { registerOrgSymbolProvider } = require("./orgSymbolProvider");
 const { registerOrgCompletionProvider } = require("./orgCompletionProvider");
+const { registerOrgPreview } = require("./orgPreview");
 const { migrateFileToV2 } = require("./migrateFileToV2");
 const { insertCheckboxItem } = require("./insertCheckboxItem");
 const { toggleCheckboxCookie } = require("./toggleCheckboxCookie");
 const { toggleCheckboxItemAtCursor } = require("./toggleCheckboxItem");
+const { insertNewElement } = require("./smartInsertNewElement");
 
 // Startup log for debugging
 console.log("📌 agenda.js has been loaded in extension.js");
@@ -164,6 +167,12 @@ function activate(ctx) {
   // Emacs-style emphasis rendering (bold/italic/underline) + hide markers when not editing them
   registerOrgEmphasisDecorations(ctx);
 
+  // Render common LaTeX commands inside math as Unicode glyphs (decorations only)
+  registerMathDecorations(ctx);
+
+  // Live preview webview (MVP) + editor -> preview scroll sync
+  registerOrgPreview(ctx);
+
   // Date format changes are not auto-applied to existing files because swapping
   // MM-DD and DD-MM can be ambiguous (e.g. 04-05-2026). Provide an explicit command instead.
   vscode.workspace.onDidChangeConfiguration((event) => {
@@ -230,6 +239,7 @@ function activate(ctx) {
   ctx.subscriptions.push(vscode.commands.registerCommand("extension.insertCheckboxItem", insertCheckboxItem));
   ctx.subscriptions.push(vscode.commands.registerCommand("extension.toggleCheckboxCookie", toggleCheckboxCookie));
   ctx.subscriptions.push(vscode.commands.registerCommand("extension.toggleCheckboxItem", toggleCheckboxItemAtCursor));
+  ctx.subscriptions.push(vscode.commands.registerCommand("org-vscode.insertNewElement", insertNewElement));
 
   // org-vscode.insertTable is registered inside insertTable.activate()
   insertTable.activate(ctx);

--- a/org-vscode/out/mathDecorations.js
+++ b/org-vscode/out/mathDecorations.js
@@ -1,0 +1,294 @@
+"use strict";
+
+const vscode = require("vscode");
+
+const DEFAULT_COMMAND_MAP = {
+  // Greek
+  "\\\\alpha": "α",
+  "\\\\beta": "β",
+  "\\\\gamma": "γ",
+  "\\\\delta": "δ",
+  "\\\\epsilon": "ε",
+  "\\\\varepsilon": "ϵ",
+  "\\\\zeta": "ζ",
+  "\\\\eta": "η",
+  "\\\\theta": "θ",
+  "\\\\vartheta": "ϑ",
+  "\\\\iota": "ι",
+  "\\\\kappa": "κ",
+  "\\\\lambda": "λ",
+  "\\\\mu": "μ",
+  "\\\\nu": "ν",
+  "\\\\xi": "ξ",
+  "\\\\pi": "π",
+  "\\\\rho": "ρ",
+  "\\\\sigma": "σ",
+  "\\\\tau": "τ",
+  "\\\\upsilon": "υ",
+  "\\\\phi": "φ",
+  "\\\\varphi": "ϕ",
+  "\\\\chi": "χ",
+  "\\\\psi": "ψ",
+  "\\\\omega": "ω",
+
+  // Uppercase Greek (common ones)
+  "\\\\Gamma": "Γ",
+  "\\\\Delta": "Δ",
+  "\\\\Theta": "Θ",
+  "\\\\Lambda": "Λ",
+  "\\\\Xi": "Ξ",
+  "\\\\Pi": "Π",
+  "\\\\Sigma": "Σ",
+  "\\\\Upsilon": "Υ",
+  "\\\\Phi": "Φ",
+  "\\\\Psi": "Ψ",
+  "\\\\Omega": "Ω",
+
+  // Operators / relations
+  "\\\\times": "×",
+  "\\\\cdot": "·",
+  "\\\\pm": "±",
+  "\\\\mp": "∓",
+  "\\\\le": "≤",
+  "\\\\leq": "≤",
+  "\\\\ge": "≥",
+  "\\\\geq": "≥",
+  "\\\\neq": "≠",
+  "\\\\approx": "≈",
+  "\\\\equiv": "≡",
+  "\\\\infty": "∞",
+  "\\\\partial": "∂",
+  "\\\\nabla": "∇",
+
+  // Set / logic
+  "\\\\in": "∈",
+  "\\\\notin": "∉",
+  "\\\\subset": "⊂",
+  "\\\\subseteq": "⊆",
+  "\\\\supset": "⊃",
+  "\\\\supseteq": "⊇",
+  "\\\\cup": "∪",
+  "\\\\cap": "∩",
+  "\\\\forall": "∀",
+  "\\\\exists": "∃",
+  "\\\\neg": "¬",
+  "\\\\wedge": "∧",
+  "\\\\vee": "∨",
+
+  // Arrows
+  "\\\\to": "→",
+  "\\\\rightarrow": "→",
+  "\\\\leftarrow": "←",
+  "\\\\Rightarrow": "⇒",
+  "\\\\Leftarrow": "⇐",
+  "\\\\leftrightarrow": "↔",
+  "\\\\Leftrightarrow": "⇔",
+
+  // Big operators
+  "\\\\sum": "∑",
+  "\\\\prod": "∏",
+  "\\\\int": "∫",
+  "\\\\iint": "∬",
+  "\\\\iiint": "∭"
+};
+
+function shouldDecorate(editor) {
+  if (!editor || !editor.document) return false;
+  const lang = editor.document.languageId;
+  if (!['vso', 'org', 'org-vscode', 'vsorg'].includes(lang)) return false;
+  const config = vscode.workspace.getConfiguration('Org-vscode');
+  return Boolean(config.get('decorateMath', true));
+}
+
+function isMathFenceLine(text) {
+  return /^\s*\$\$\s*$/.test(text);
+}
+
+function findInlineMathSpans(text) {
+  const spans = [];
+  let i = 0;
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === '\\') {
+      i += 2;
+      continue;
+    }
+
+    if (ch !== '$') {
+      i++;
+      continue;
+    }
+
+    // Ignore $$ (block fence). Inline is a single $ not adjacent to another $.
+    const prev = i > 0 ? text[i - 1] : '';
+    const next = i + 1 < text.length ? text[i + 1] : '';
+    if (next === '$' || prev === '$') {
+      i++;
+      continue;
+    }
+
+    const start = i;
+    i++;
+    let end = -1;
+    while (i < text.length) {
+      const c = text[i];
+      if (c === '\\') {
+        i += 2;
+        continue;
+      }
+      if (c === '$') {
+        const n2 = i + 1 < text.length ? text[i + 1] : '';
+        const p2 = i > 0 ? text[i - 1] : '';
+        if (n2 !== '$' && p2 !== '$') {
+          end = i;
+          break;
+        }
+      }
+      i++;
+    }
+
+    if (end !== -1 && end > start) {
+      // inner content is (start+1 .. end)
+      spans.push({ start: start + 1, end });
+      i = end + 1;
+      continue;
+    }
+
+    // Unclosed.
+    i = start + 1;
+  }
+  return spans;
+}
+
+function inSpan(index, spans) {
+  for (const s of spans) {
+    if (s.start <= index && index < s.end) return true;
+  }
+  return false;
+}
+
+function computeDecorationsForEditor(editor) {
+  const document = editor.document;
+  const visible = (editor.visibleRanges && editor.visibleRanges.length)
+    ? editor.visibleRanges
+    : [new vscode.Range(new vscode.Position(0, 0), new vscode.Position(Math.max(0, document.lineCount - 1), 0))];
+
+  // Heuristic: determine math block state by scanning a bounded number of lines above the first visible line.
+  const firstVisibleLine = Math.max(0, visible[0].start.line);
+  const scanBack = Math.max(0, firstVisibleLine - 200);
+  let inBlockMath = false;
+  for (let ln = scanBack; ln < firstVisibleLine; ln++) {
+    const t = document.lineAt(ln).text;
+    if (isMathFenceLine(t)) inBlockMath = !inBlockMath;
+  }
+
+  const decorations = [];
+  const commandRegex = /\\[A-Za-z]+/g;
+
+  for (const visibleRange of visible) {
+    const startLine = Math.max(0, visibleRange.start.line);
+    const endLine = Math.min(document.lineCount - 1, visibleRange.end.line + 2);
+
+    for (let lineNumber = startLine; lineNumber <= endLine; lineNumber++) {
+      const text = document.lineAt(lineNumber).text;
+
+      if (isMathFenceLine(text)) {
+        inBlockMath = !inBlockMath;
+        continue;
+      }
+
+      const inlineSpans = findInlineMathSpans(text);
+
+      commandRegex.lastIndex = 0;
+      let match;
+      while ((match = commandRegex.exec(text)) != null) {
+        const command = match[0];
+        const symbol = DEFAULT_COMMAND_MAP[command];
+        if (!symbol) continue;
+
+        const startChar = match.index;
+        const endChar = startChar + command.length;
+
+        const insideMath = inBlockMath || inSpan(startChar, inlineSpans);
+        if (!insideMath) continue;
+
+        decorations.push({
+          range: new vscode.Range(lineNumber, startChar, lineNumber, endChar),
+          renderOptions: {
+            before: {
+              contentText: symbol,
+              margin: '0 0.1em 0 0'
+            }
+          }
+        });
+      }
+    }
+  }
+
+  return decorations;
+}
+
+function registerMathDecorations(ctx) {
+  if (!vscode.window || typeof vscode.window.createTextEditorDecorationType !== 'function') {
+    return;
+  }
+
+  // NOTE: Avoid hiding the underlying LaTeX command text here.
+  // Some CSS approaches (e.g. font-size: 0 / transparent) can also hide the
+  // inserted `before` content, making decorations appear to "not work".
+  const mathSymbolType = vscode.window.createTextEditorDecorationType({
+    textDecoration: 'none;'
+  });
+
+  ctx.subscriptions.push(mathSymbolType);
+
+  let pendingTimer = null;
+
+  function clear(editor) {
+    if (!editor) return;
+    editor.setDecorations(mathSymbolType, []);
+  }
+
+  function apply(editor) {
+    if (!editor) return;
+
+    if (!shouldDecorate(editor)) {
+      clear(editor);
+      return;
+    }
+
+    const decorations = computeDecorationsForEditor(editor);
+    editor.setDecorations(mathSymbolType, decorations);
+  }
+
+  function scheduleApply(editor) {
+    if (pendingTimer) clearTimeout(pendingTimer);
+    pendingTimer = setTimeout(() => {
+      pendingTimer = null;
+      apply(editor || vscode.window.activeTextEditor);
+    }, 75);
+  }
+
+  scheduleApply(vscode.window.activeTextEditor);
+
+  ctx.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor((editor) => scheduleApply(editor)),
+    vscode.window.onDidChangeTextEditorSelection((event) => {
+      if (event.textEditor === vscode.window.activeTextEditor) scheduleApply(event.textEditor);
+    }),
+    vscode.window.onDidChangeTextEditorVisibleRanges((event) => {
+      if (event.textEditor === vscode.window.activeTextEditor) scheduleApply(event.textEditor);
+    }),
+    vscode.workspace.onDidChangeTextDocument((event) => {
+      const active = vscode.window.activeTextEditor;
+      if (active && event.document.uri.toString() === active.document.uri.toString()) scheduleApply(active);
+    }),
+    vscode.workspace.onDidChangeConfiguration((event) => {
+      if (event.affectsConfiguration('Org-vscode.decorateMath')) scheduleApply(vscode.window.activeTextEditor);
+    })
+  );
+}
+
+module.exports = {
+  registerMathDecorations
+};

--- a/org-vscode/out/orgPreview.js
+++ b/org-vscode/out/orgPreview.js
@@ -1,0 +1,327 @@
+"use strict";
+
+const vscode = require("vscode");
+
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function getNonce() {
+  const possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  let text = "";
+  for (let i = 0; i < 32; i++) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+  }
+  return text;
+}
+
+function isOrgDoc(editor) {
+  if (!editor || !editor.document) return false;
+  return ["vso", "org", "org-vscode", "vsorg"].includes(editor.document.languageId);
+}
+
+function renderOrgToHtml(documentText) {
+  // Minimal Org→HTML renderer (MVP): headings, lists, checkboxes, code blocks, tables, and export html blocks.
+  // This is intentionally conservative; we can replace it later with a full Org parser.
+  const lines = documentText.split(/\r?\n/);
+  const out = [];
+
+  let inSrc = false;
+  let srcLang = "";
+  let inExportHtml = false;
+  let listStack = []; // array of "ul" or "ol"
+  let inTable = false;
+
+  function closeLists() {
+    while (listStack.length) {
+      out.push(`</${listStack.pop()}>`);
+    }
+  }
+
+  function closeTable() {
+    if (inTable) {
+      out.push("</tbody></table>");
+      inTable = false;
+    }
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i];
+    const lineNo = i + 1;
+    const trimmed = raw.trim();
+
+    // Always include a marker at each line so scroll sync is deterministic.
+    const marker = `<span class="line-marker" data-line="${lineNo}"></span>`;
+
+    // Export HTML block: include raw HTML
+    if (!inSrc && !inExportHtml && /^\s*#\+BEGIN_EXPORT\s+html\s*$/i.test(raw)) {
+      closeLists();
+      closeTable();
+      inExportHtml = true;
+      out.push(`<div class="org-export-html">${marker}`);
+      continue;
+    }
+    if (inExportHtml) {
+      if (/^\s*#\+END_EXPORT\s*$/i.test(raw)) {
+        out.push(`${marker}</div>`);
+        inExportHtml = false;
+      } else {
+        out.push(`${marker}${raw}`);
+      }
+      continue;
+    }
+
+    // Src blocks
+    const beginSrc = raw.match(/^\s*#\+BEGIN_SRC\s*(\S+)?\s*$/i);
+    if (!inSrc && beginSrc) {
+      closeLists();
+      closeTable();
+      inSrc = true;
+      srcLang = (beginSrc[1] || "").toLowerCase();
+      out.push(`<pre class="org-src"><code data-lang="${escapeHtml(srcLang)}">${marker}`);
+      continue;
+    }
+    if (inSrc) {
+      if (/^\s*#\+END_SRC\s*$/i.test(raw)) {
+        out.push(`${marker}</code></pre>`);
+        inSrc = false;
+        srcLang = "";
+      } else {
+        out.push(`${marker}${escapeHtml(raw)}\n`);
+      }
+      continue;
+    }
+
+    // Tables (very minimal)
+    if (/^\s*\|.*\|\s*$/.test(raw)) {
+      closeLists();
+      if (!inTable) {
+        out.push(`<table class="org-table"><tbody>`);
+        inTable = true;
+      }
+      const cells = raw.trim().replace(/^\|/, "").replace(/\|$/, "").split("|");
+      out.push(`<tr>${marker}${cells.map((c) => `<td>${escapeHtml(c.trim())}</td>`).join("")}</tr>`);
+      continue;
+    } else {
+      closeTable();
+    }
+
+    // Headings
+    const heading = raw.match(/^\s*(\*+)\s+(.*)$/);
+    if (heading) {
+      closeLists();
+      const level = Math.min(6, heading[1].length);
+      const title = escapeHtml(heading[2]);
+      out.push(`<h${level} class="org-heading">${marker}${title}</h${level}>`);
+      continue;
+    }
+
+    // Lists (simple; no nesting by indentation yet)
+    const ordered = raw.match(/^\s*(\d+)\.\s+(.*)$/);
+    const unordered = raw.match(/^\s*([-+])\s+(.*)$/);
+    if (ordered || unordered) {
+      closeTable();
+      const type = ordered ? "ol" : "ul";
+      const body = ordered ? ordered[2] : unordered[2];
+      const checkbox = body.match(/^\[( |x|X)\]\s+(.*)$/);
+
+      if (!listStack.length || listStack[listStack.length - 1] !== type) {
+        closeLists();
+        listStack.push(type);
+        out.push(`<${type} class="org-list">`);
+      }
+
+      if (checkbox) {
+        const checked = /x/i.test(checkbox[1]);
+        out.push(
+          `<li>${marker}<input type="checkbox" disabled ${checked ? "checked" : ""} /> ${escapeHtml(checkbox[2])}</li>`
+        );
+      } else {
+        out.push(`<li>${marker}${escapeHtml(body)}</li>`);
+      }
+      continue;
+    }
+
+    // Blank line
+    if (trimmed.length === 0) {
+      closeLists();
+      closeTable();
+      out.push(`<div class="org-blank">${marker}</div>`);
+      continue;
+    }
+
+    // Paragraph
+    closeLists();
+    closeTable();
+    out.push(`<p class="org-paragraph">${marker}${escapeHtml(raw)}</p>`);
+  }
+
+  closeLists();
+  closeTable();
+
+  return out.join("\n");
+}
+
+function getPreviewHtml(webview, nonce, bodyHtml) {
+  const csp = `default-src 'none'; img-src ${webview.cspSource} https: data:; style-src ${webview.cspSource} 'unsafe-inline'; script-src ${webview.cspSource} 'nonce-${nonce}'; font-src ${webview.cspSource} https: data:`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy" content="${csp}" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Org Preview</title>
+  <style>
+    body{padding:16px; color:var(--vscode-editor-foreground); background:var(--vscode-editor-background); font-family:var(--vscode-font-family); font-size:var(--vscode-font-size); line-height:1.5;}
+    .org-heading{margin:1.2em 0 .4em 0;}
+    .org-paragraph{margin:.3em 0; white-space:pre-wrap;}
+    .org-list{margin:.3em 0 .6em 1.2em; padding:0;}
+    .org-list li{margin:.15em 0;}
+    .org-src{background:var(--vscode-textCodeBlock-background); padding:10px; overflow:auto; border-radius:2px;}
+    .org-table{border-collapse:collapse; margin:.4em 0;}
+    .org-table td{border:1px solid var(--vscode-editorWidget-border); padding:2px 6px;}
+    .line-marker{display:inline-block; width:0; height:0;}
+    .org-export-html{margin:.4em 0;}
+  </style>
+</head>
+<body>
+  <div id="root">${bodyHtml}</div>
+  <script nonce="${nonce}">
+    const vscode = acquireVsCodeApi();
+    function scrollToLine(line){
+      const marker = document.querySelector('.line-marker[data-line="' + String(line) + '"]');
+      if (!marker) return;
+      marker.scrollIntoView({ block: 'center', behavior: 'auto' });
+    }
+    window.addEventListener('message', (event) => {
+      const msg = event.data;
+      if (!msg || !msg.type) return;
+      if (msg.type === 'scrollToLine') {
+        scrollToLine(msg.line);
+      }
+    });
+  </script>
+</body>
+</html>`;
+}
+
+class OrgPreviewManager {
+  constructor(ctx) {
+    this.ctx = ctx;
+    this.panel = null;
+    this.targetUri = null;
+    this.pendingTimer = null;
+  }
+
+  open(viewColumn) {
+    const editor = vscode.window.activeTextEditor;
+    if (!isOrgDoc(editor)) {
+      vscode.window.showInformationMessage("Org-vscode: Open an Org file to preview.");
+      return;
+    }
+
+    const doc = editor.document;
+    this.targetUri = doc.uri;
+
+    if (this.panel) {
+      this.panel.reveal(viewColumn);
+      this.refreshNow();
+      return;
+    }
+
+    this.panel = vscode.window.createWebviewPanel(
+      "org-vscode.preview",
+      "Org Preview",
+      viewColumn,
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true
+      }
+    );
+
+    this.panel.onDidDispose(() => {
+      this.panel = null;
+      this.targetUri = null;
+    });
+
+    this.refreshNow();
+  }
+
+  refreshNow() {
+    if (!this.panel || !this.targetUri) return;
+
+    const doc = vscode.workspace.textDocuments.find((d) => d.uri.toString() === this.targetUri.toString());
+    if (!doc) return;
+
+    const body = renderOrgToHtml(doc.getText());
+    const nonce = getNonce();
+    this.panel.webview.html = getPreviewHtml(this.panel.webview, nonce, body);
+  }
+
+  scheduleRefresh() {
+    if (!this.panel) return;
+    if (this.pendingTimer) clearTimeout(this.pendingTimer);
+    this.pendingTimer = setTimeout(() => {
+      this.pendingTimer = null;
+      this.refreshNow();
+    }, 150);
+  }
+
+  postScrollToLine(line) {
+    if (!this.panel) return;
+    this.panel.webview.postMessage({ type: "scrollToLine", line: line + 1 });
+  }
+}
+
+function registerOrgPreview(ctx) {
+  const manager = new OrgPreviewManager(ctx);
+
+  ctx.subscriptions.push(
+    vscode.commands.registerCommand("org-vscode.openPreview", () => manager.open(vscode.ViewColumn.One)),
+    vscode.commands.registerCommand("org-vscode.openPreviewToSide", () => manager.open(vscode.ViewColumn.Beside))
+  );
+
+  if (vscode.workspace && typeof vscode.workspace.onDidChangeTextDocument === "function") {
+    ctx.subscriptions.push(
+      vscode.workspace.onDidChangeTextDocument((event) => {
+        if (!manager.panel || !manager.targetUri) return;
+        if (event.document.uri.toString() !== manager.targetUri.toString()) return;
+        manager.scheduleRefresh();
+      })
+    );
+  }
+
+  if (vscode.window && typeof vscode.window.onDidChangeActiveTextEditor === "function") {
+    ctx.subscriptions.push(
+      vscode.window.onDidChangeActiveTextEditor((editor) => {
+        if (!manager.panel || !manager.targetUri) return;
+        if (!editor || !editor.document) return;
+        if (editor.document.uri.toString() !== manager.targetUri.toString()) return;
+        manager.scheduleRefresh();
+      })
+    );
+  }
+
+  if (vscode.window && typeof vscode.window.onDidChangeTextEditorVisibleRanges === "function") {
+    ctx.subscriptions.push(
+      vscode.window.onDidChangeTextEditorVisibleRanges((event) => {
+        if (!manager.panel || !manager.targetUri) return;
+        if (!event.textEditor || !event.textEditor.document) return;
+        if (event.textEditor.document.uri.toString() !== manager.targetUri.toString()) return;
+        const vr = event.visibleRanges && event.visibleRanges[0];
+        if (!vr) return;
+        manager.postScrollToLine(vr.start.line);
+      })
+    );
+  }
+}
+
+module.exports = {
+  registerOrgPreview
+};

--- a/org-vscode/out/smartInsertNewElement.js
+++ b/org-vscode/out/smartInsertNewElement.js
@@ -1,0 +1,281 @@
+"use strict";
+
+let vscode;
+
+function getVscode() {
+  if (vscode) return vscode;
+  try {
+    // Only available inside the VS Code extension host.
+    vscode = require("vscode");
+    return vscode;
+  } catch {
+    return null;
+  }
+}
+
+const ORG_LANG_IDS = new Set(["vso", "org", "vsorg", "org-vscode"]);
+
+const STAR_HEADING_REGEX = /^(\s*)(\*+)\s+(.*)$/;
+const UNICODE_HEADING_REGEX = /^(\s*)([⊙⊘⊖⊜⊗])\s+(.*)$/;
+
+// Keep list parsing consistent with our grammar decision: no '*' unordered bullets.
+const UNORDERED_LIST_ITEM_REGEX = /^(\s*)([-+])\s+(.*)$/;
+const ORDERED_LIST_ITEM_REGEX = /^(\s*)(\d+)([.)])\s+(.*)$/;
+
+const CHECKBOX_ITEM_REGEX = /^(\s*)((?:[-+])|(?:\d+[.)]))\s+\[( |x|X|-)\]\s*(.*)$/;
+const TABLE_ROW_REGEX = /^(\s*)\|/;
+
+function isOrgLanguageId(languageId) {
+  return ORG_LANG_IDS.has(String(languageId || ""));
+}
+
+function parseHeadingLineForInsert(text) {
+  const s = String(text || "");
+
+  const star = s.match(STAR_HEADING_REGEX);
+  if (star) {
+    const leading = star[1] || "";
+    const stars = star[2] || "*";
+    return { kind: "heading", style: "star", level: stars.length, leading, marker: stars };
+  }
+
+  const uni = s.match(UNICODE_HEADING_REGEX);
+  if (uni) {
+    const leading = uni[1] || "";
+    const symbol = uni[2] || "⊙";
+    const level = Math.floor(leading.length / 2) + 1;
+    return { kind: "heading", style: "unicode", level, leading, marker: symbol };
+  }
+
+  return null;
+}
+
+function parseListItemForInsert(text) {
+  const s = String(text || "");
+
+  const checkbox = s.match(CHECKBOX_ITEM_REGEX);
+  if (checkbox) {
+    const leading = checkbox[1] || "";
+    const bullet = checkbox[2] || "-";
+    return { kind: "list", leading, bullet, isCheckbox: true };
+  }
+
+  const unordered = s.match(UNORDERED_LIST_ITEM_REGEX);
+  if (unordered) {
+    const leading = unordered[1] || "";
+    const bullet = unordered[2] || "-";
+    return { kind: "list", leading, bullet, isCheckbox: false };
+  }
+
+  const ordered = s.match(ORDERED_LIST_ITEM_REGEX);
+  if (ordered) {
+    const leading = ordered[1] || "";
+    const n = Number(ordered[2]);
+    const delim = ordered[3] || ".";
+    const next = Number.isFinite(n) ? (n + 1) : 1;
+    return { kind: "list", leading, bullet: `${next}${delim}`, isCheckbox: false };
+  }
+
+  return null;
+}
+
+function countOrgTableColumns(lineText) {
+  const s = String(lineText || "");
+  // Split on '|' and drop the leading/trailing empties.
+  const parts = s.split("|");
+  if (parts.length < 3) return 1;
+  return Math.max(1, parts.length - 2);
+}
+
+function isHeadingLine(text) {
+  return Boolean(parseHeadingLineForInsert(text));
+}
+
+function getHeadingLevel(text) {
+  const parsed = parseHeadingLineForInsert(text);
+  return parsed ? Math.max(1, parsed.level) : null;
+}
+
+function isListItemLine(text) {
+  return Boolean(parseListItemForInsert(text));
+}
+
+function getIndentLength(text) {
+  const m = String(text || "").match(/^\s*/);
+  return m ? m[0].length : 0;
+}
+
+function findHeadingSubtreeEndExclusive(lines, headingLineIndex, headingLevel) {
+  const safeLines = Array.isArray(lines) ? lines : [];
+  const start = Math.max(0, Number(headingLineIndex) || 0);
+  const level = Math.max(1, Number(headingLevel) || 1);
+
+  for (let i = start + 1; i < safeLines.length; i++) {
+    const l = safeLines[i];
+    const lvl = getHeadingLevel(l);
+    if (lvl != null && lvl <= level) {
+      return i;
+    }
+  }
+
+  return safeLines.length;
+}
+
+function findListItemSubtreeEndExclusive(lines, listLineIndex, baseIndent) {
+  const safeLines = Array.isArray(lines) ? lines : [];
+  const start = Math.max(0, Number(listLineIndex) || 0);
+  const indent = Math.max(0, Number(baseIndent) || 0);
+
+  for (let i = start + 1; i < safeLines.length; i++) {
+    const l = safeLines[i];
+    if (isHeadingLine(l)) {
+      return i;
+    }
+    if (isListItemLine(l) && getIndentLength(l) <= indent) {
+      return i;
+    }
+  }
+
+  return safeLines.length;
+}
+
+function findNearestHeadingLineIndex(lines, fromLineIndex) {
+  const safeLines = Array.isArray(lines) ? lines : [];
+  for (let i = Math.max(0, Number(fromLineIndex) || 0); i >= 0; i--) {
+    if (isHeadingLine(safeLines[i])) return i;
+  }
+  return null;
+}
+
+function computeSmartInsertNewElement(lines, cursorLineIndex) {
+  const safeLines = Array.isArray(lines) ? lines : [];
+  const lineIndex = Math.max(0, Number(cursorLineIndex) || 0);
+  const current = safeLines[lineIndex] ?? "";
+
+  // 1) Table row: insert a new empty row below.
+  const tableMatch = String(current).match(TABLE_ROW_REGEX);
+  if (tableMatch) {
+    const leading = tableMatch[1] || "";
+    const cols = countOrgTableColumns(String(current).trimEnd());
+    const cells = Array(cols).fill("   ").join("|");
+    const newLineText = `${leading}|${cells}|`;
+    return {
+      insertBeforeLineIndex: lineIndex + 1,
+      newLineText,
+      cursorColumn: newLineText.length
+    };
+  }
+
+  // 2) List item: insert a new sibling item after this item's subtree.
+  const list = parseListItemForInsert(current);
+  if (list) {
+    const subtreeEnd = findListItemSubtreeEndExclusive(safeLines, lineIndex, list.leading.length);
+    const bullet = list.bullet;
+    const newLineText = list.isCheckbox
+      ? `${list.leading}${bullet} [ ] `
+      : `${list.leading}${bullet} `;
+
+    return {
+      insertBeforeLineIndex: subtreeEnd,
+      newLineText,
+      cursorColumn: newLineText.length
+    };
+  }
+
+  // 3) Heading line: insert new sibling heading after this subtree.
+  const heading = parseHeadingLineForInsert(current);
+  if (heading) {
+    const subtreeEnd = findHeadingSubtreeEndExclusive(safeLines, lineIndex, heading.level);
+    const newLineText = `${heading.leading}${heading.marker} `;
+    return {
+      insertBeforeLineIndex: subtreeEnd,
+      newLineText,
+      cursorColumn: newLineText.length
+    };
+  }
+
+  // 4) Plain text: use nearest heading context if present.
+  const nearestHeading = findNearestHeadingLineIndex(safeLines, lineIndex);
+  if (nearestHeading != null) {
+    const h = parseHeadingLineForInsert(safeLines[nearestHeading]);
+    if (h) {
+      const subtreeEnd = findHeadingSubtreeEndExclusive(safeLines, nearestHeading, h.level);
+      const newLineText = `${h.leading}${h.marker} `;
+      return {
+        insertBeforeLineIndex: subtreeEnd,
+        newLineText,
+        cursorColumn: newLineText.length
+      };
+    }
+  }
+
+  // 5) No context: insert a top-level star heading at cursor line.
+  return {
+    insertBeforeLineIndex: lineIndex,
+    newLineText: "* ",
+    cursorColumn: 2
+  };
+}
+
+function computeInsertEditForDocument(document, insertBeforeLineIndex, newLineText) {
+  const vs = getVscode();
+  if (!vs) {
+    throw new Error("vscode API is not available (must run inside VS Code extension host)");
+  }
+
+  const targetLine = Number(insertBeforeLineIndex);
+  const docLineCount = document.lineCount;
+
+  if (targetLine >= docLineCount) {
+    const lastLine = document.lineAt(docLineCount - 1);
+    const needsLeadingNewline = lastLine.text.length > 0;
+    return {
+      insertPosition: lastLine.range.end,
+      insertText: (needsLeadingNewline ? "\n" : "") + String(newLineText || ""),
+      insertedLineIndex: needsLeadingNewline ? docLineCount : (docLineCount - 1)
+    };
+  }
+
+  const pos = new vs.Position(targetLine, 0);
+  return {
+    insertPosition: pos,
+    insertText: String(newLineText || "") + "\n",
+    insertedLineIndex: targetLine
+  };
+}
+
+async function insertNewElement() {
+  const vs = getVscode();
+  if (!vs) return;
+
+  const editor = vs.window.activeTextEditor;
+  if (!editor || !editor.document || !isOrgLanguageId(editor.document.languageId)) {
+    return;
+  }
+
+  const doc = editor.document;
+  const cursorLine = editor.selection.active.line;
+  const lines = doc.getText().split(/\r?\n/);
+
+  const plan = computeSmartInsertNewElement(lines, cursorLine);
+  if (!plan || !plan.newLineText) {
+    return;
+  }
+
+  const editPlan = computeInsertEditForDocument(doc, plan.insertBeforeLineIndex, plan.newLineText);
+
+  const ok = await editor.edit((eb) => {
+    eb.insert(editPlan.insertPosition, editPlan.insertText);
+  });
+
+  if (!ok) return;
+
+  const newPos = new vs.Position(editPlan.insertedLineIndex, plan.cursorColumn);
+  editor.selection = new vs.Selection(newPos, newPos);
+  editor.revealRange(new vs.Range(newPos, newPos));
+}
+
+module.exports = {
+  insertNewElement,
+  computeSmartInsertNewElement
+};

--- a/org-vscode/test/unit/run.js
+++ b/org-vscode/test/unit/run.js
@@ -10,7 +10,8 @@ const tests = [
   require(path.join(__dirname, 'checkbox-stats.test.js')),
   require(path.join(__dirname, 'checkbox-cookie-toggle.test.js')),
   require(path.join(__dirname, 'checkbox-auto-done.test.js')),
-  require(path.join(__dirname, 'checkbox-toggle.test.js'))
+  require(path.join(__dirname, 'checkbox-toggle.test.js')),
+  require(path.join(__dirname, 'smart-insert-new-element.test.js'))
 ];
 
 async function main() {

--- a/org-vscode/test/unit/smart-insert-new-element.test.js
+++ b/org-vscode/test/unit/smart-insert-new-element.test.js
@@ -1,0 +1,84 @@
+const assert = require('assert');
+const path = require('path');
+
+const {
+  computeSmartInsertNewElement
+} = require(path.join(__dirname, '..', '..', 'out', 'smartInsertNewElement.js'));
+
+function testHeadingInsertsAfterSubtree() {
+  const lines = [
+    '* Parent',
+    'Some body',
+    '** Child',
+    'More',
+    '* Next'
+  ];
+
+  const plan = computeSmartInsertNewElement(lines, 0);
+  assert.deepStrictEqual(
+    plan,
+    {
+      insertBeforeLineIndex: 4,
+      newLineText: '* ',
+      cursorColumn: 2
+    }
+  );
+}
+
+function testListItemInsertsSiblingAfterSubtree() {
+  const lines = [
+    '* H',
+    '  - one',
+    '    - child',
+    '  - two',
+    '* H2'
+  ];
+
+  const plan = computeSmartInsertNewElement(lines, 1);
+  assert.strictEqual(plan.insertBeforeLineIndex, 3);
+  assert.strictEqual(plan.newLineText, '  - ');
+}
+
+function testCheckboxListItemInsertsUnchecked() {
+  const lines = [
+    '- [X] done item',
+    '- [ ] open item'
+  ];
+
+  const plan = computeSmartInsertNewElement(lines, 0);
+  assert.strictEqual(plan.insertBeforeLineIndex, 1);
+  assert.strictEqual(plan.newLineText, '- [ ] ');
+}
+
+function testOrderedListIncrements() {
+  const lines = [
+    '1. first',
+    '2. second'
+  ];
+
+  const plan = computeSmartInsertNewElement(lines, 0);
+  assert.strictEqual(plan.insertBeforeLineIndex, 1);
+  assert.strictEqual(plan.newLineText, '2. ');
+}
+
+function testTableRowInsertsEmptyRow() {
+  const lines = [
+    '| A | B |',
+    '| 1 | 2 |'
+  ];
+
+  const plan = computeSmartInsertNewElement(lines, 0);
+  assert.strictEqual(plan.insertBeforeLineIndex, 1);
+  assert.strictEqual(plan.newLineText, '|   |   |');
+}
+
+module.exports = {
+  name: 'unit/smart-insert-new-element',
+  run: () => {
+    testHeadingInsertsAfterSubtree();
+    testListItemInsertsSiblingAfterSubtree();
+    testCheckboxListItemInsertsUnchecked();
+    testOrderedListIncrements();
+    testTableRowInsertsEmptyRow();
+  }
+};

--- a/org-vscode/vso.tmLanguage.json
+++ b/org-vscode/vso.tmLanguage.json
@@ -306,14 +306,37 @@
           "name": "meta.block.math.vso",
           "begin": "^\\s*\\$\\$\\s*$",
           "end": "^\\s*\\$\\$\\s*$",
+          "beginCaptures": {
+            "0": { "name": "punctuation.definition.math.block.vso" }
+          },
+          "endCaptures": {
+            "0": { "name": "punctuation.definition.math.block.vso" }
+          },
           "patterns": [
+            { "name": "support.function.latex.command.vso", "match": "\\\\\\\\[A-Za-z]+" },
+            { "name": "constant.character.escape.latex.vso", "match": "\\\\\\\\." },
+            { "name": "punctuation.section.group.latex.vso", "match": "[{}\\\\[\\\\]()]" },
+            { "name": "keyword.operator.math.vso", "match": "[\\^_=+\\-*/]" },
             { "include": "#org_emphasis" },
             { "include": "#org_links" }
           ]
         },
         {
           "name": "string.other.math.inline.vso",
-          "match": "(?<!\\$)\\$[^\\$\\n]+\\$(?!\\$)"
+          "begin": "(?<!\\$)\\$",
+          "beginCaptures": {
+            "0": { "name": "punctuation.definition.math.inline.vso" }
+          },
+          "end": "\\$(?!\\$)",
+          "endCaptures": {
+            "0": { "name": "punctuation.definition.math.inline.vso" }
+          },
+          "patterns": [
+            { "name": "support.function.latex.command.vso", "match": "\\\\\\\\[A-Za-z]+" },
+            { "name": "constant.character.escape.latex.vso", "match": "\\\\\\\\." },
+            { "name": "punctuation.section.group.latex.vso", "match": "[{}\\\\[\\\\]()]" },
+            { "name": "keyword.operator.math.vso", "match": "[\\^_=+\\-*/]" }
+          ]
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "org-vscode",
 	"displayName": "org-vscode",
 	"description": "Quickly create todo lists, take notes, plan projects and organize your thoughts.",
-	"version": "2.1.5",
+	"version": "2.2.0",
 	"repository": "https://www.github.com/realDestroyer/org-vscode",
 	"icon": "Logo.png",
 	"publisher": "realDestroyer",
@@ -20,13 +20,16 @@
 		"onLanguage:vsorg",
 		"onLanguage:org-vscode",
 		"onLanguage:vso",
+		"onCommand:org-vscode.openPreview",
+		"onCommand:org-vscode.openPreviewToSide",
 		"onCommand:extension.viewAgenda",
 		"onCommand:extension.migrateFileToV2",
 		"onCommand:extension.createVsoFile",
 		"onCommand:extension.openSyntaxColorCustomizer",
 		"onCommand:orgMode.exportYearSummary",
 		"onCommand:orgMode.generateExecutiveReport",
-		"onCommand:orgMode.openYearInReview"
+		"onCommand:orgMode.openYearInReview",
+		"onCommand:org-vscode.insertNewElement"
 	],
 	"keywords": [
 		"todo",
@@ -331,6 +334,12 @@
 					"order": 10,
 					"default": true,
 					"description": "Render Org emphasis markers (*bold*, /italic/, _underline_) using editor decorations and hide the marker characters unless the cursor is on them."
+				},
+				"Org-vscode.decorateMath": {
+					"type": "boolean",
+					"order": 10.5,
+					"default": true,
+					"description": "Render common LaTeX commands (e.g. \\alpha, \\sum) inside $...$ and $$...$$ math using editor decorations."
 				}
 			}
 		},
@@ -338,6 +347,18 @@
 			{
 				"command": "extension.setFolderPath",
 				"title": "org-vscode Change Org-vscode Directory"
+			},
+			{
+				"command": "org-vscode.openPreview",
+				"title": "Org-vscode: Open Preview"
+			},
+			{
+				"command": "org-vscode.openPreviewToSide",
+				"title": "Org-vscode: Open Preview to Side"
+			},
+			{
+				"command": "org-vscode.insertNewElement",
+				"title": "Org-vscode: Insert New Element (Smart)"
 			},
 			{
 				"command": "extension.migrateFileToV2",
@@ -465,6 +486,21 @@
 			}
 		],
 		"keybindings": [
+			{
+				"command": "org-vscode.openPreviewToSide",
+				"key": "ctrl+alt+p",
+				"when": "(editorLangId == 'vso' || editorLangId == 'org' || editorLangId == 'vsorg' || editorLangId == 'org-vscode') && editorTextFocus"
+			},
+			{
+				"command": "org-vscode.insertNewElement",
+				"key": "alt+enter",
+				"when": "(editorLangId == 'vso' || editorLangId == 'org' || editorLangId == 'vsorg' || editorLangId == 'org-vscode') && editorTextFocus"
+			},
+			{
+				"command": "extension.toggleCheckboxItem",
+				"key": "ctrl+alt+x",
+				"when": "(editorLangId == 'vso' || editorLangId == 'org' || editorLangId == 'vsorg' || editorLangId == 'org-vscode') && editorTextFocus"
+			},
 			{
 				"key": "ctrl+right",
 				"command": "-extension.incrementDate"

--- a/vso.tmLanguage.json
+++ b/vso.tmLanguage.json
@@ -306,14 +306,37 @@
           "name": "meta.block.math.vso",
           "begin": "^\\s*\\$\\$\\s*$",
           "end": "^\\s*\\$\\$\\s*$",
+          "beginCaptures": {
+            "0": { "name": "punctuation.definition.math.block.vso" }
+          },
+          "endCaptures": {
+            "0": { "name": "punctuation.definition.math.block.vso" }
+          },
           "patterns": [
+            { "name": "support.function.latex.command.vso", "match": "\\\\\\\\[A-Za-z]+" },
+            { "name": "constant.character.escape.latex.vso", "match": "\\\\\\\\." },
+            { "name": "punctuation.section.group.latex.vso", "match": "[{}\\\\[\\\\]()]" },
+            { "name": "keyword.operator.math.vso", "match": "[\\^_=+\\-*/]" },
             { "include": "#org_emphasis" },
             { "include": "#org_links" }
           ]
         },
         {
           "name": "string.other.math.inline.vso",
-          "match": "(?<!\\$)\\$[^\\$\\n]+\\$(?!\\$)"
+          "begin": "(?<!\\$)\\$",
+          "beginCaptures": {
+            "0": { "name": "punctuation.definition.math.inline.vso" }
+          },
+          "end": "\\$(?!\\$)",
+          "endCaptures": {
+            "0": { "name": "punctuation.definition.math.inline.vso" }
+          },
+          "patterns": [
+            { "name": "support.function.latex.command.vso", "match": "\\\\\\\\[A-Za-z]+" },
+            { "name": "constant.character.escape.latex.vso", "match": "\\\\\\\\." },
+            { "name": "punctuation.section.group.latex.vso", "match": "[{}\\\\[\\\\]()]" },
+            { "name": "keyword.operator.math.vso", "match": "[\\^_=+\\-*/]" }
+          ]
         }
       ]
     },


### PR DESCRIPTION
## Summary
- Release prep for v2.2.0 (version bump + docs aligned)
- Adds Live Preview (HTML) with editor → preview scroll sync
- Adds Org Meta-Return style smart insert (`Alt+Enter`)
- Adds experimental math symbol decorations (`Org-vscode.decorateMath`)

## Validation
- `npm test` (outer) passes
- `npm run test:unit` (inner) passes
- `npm run package` produces `org-vscode-2.2.0.vsix`

## Notes
- Math decorations currently render a Unicode glyph *in addition to* the LaTeX command (keeps raw text visible for now to avoid CSS hiding issues).