### PR TITLE
Guard math decorations against backslash regression

### DIFF
--- a/org-vscode/out/mathDecorations.js
+++ b/org-vscode/out/mathDecorations.js
@@ -203,7 +203,9 @@ function computeDecorationsForEditor(editor) {
       let match;
       while ((match = commandRegex.exec(text)) != null) {
         const command = match[0];
-        const symbol = DEFAULT_COMMAND_MAP[command];
+        // Back-compat/robustness: some builds have map keys using "\\\\alpha" (string value "\\alpha").
+        // Our regex yields "\\alpha" (string value "\alpha"). Try both forms.
+        const symbol = DEFAULT_COMMAND_MAP[command] || DEFAULT_COMMAND_MAP["\\" + command];
         if (!symbol) continue;
 
         const startChar = match.index;

--- a/org-vscode/test/unit/math-decorations-map.test.js
+++ b/org-vscode/test/unit/math-decorations-map.test.js
@@ -1,0 +1,37 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+function testDefaultCommandMapKeysMatchCommandRegexOutput() {
+  const filePath = path.join(__dirname, '..', '..', 'out', 'mathDecorations.js');
+  const text = fs.readFileSync(filePath, 'utf8');
+
+  assert.ok(
+    /const\s+DEFAULT_COMMAND_MAP\s*=\s*\{/.test(text),
+    'Expected mathDecorations.js to contain DEFAULT_COMMAND_MAP'
+  );
+
+  // In JS source, a correct LaTeX command key looks like "\\alpha" (string value is "\alpha").
+  // A double-escaped key looks like "\\\\alpha" (string value is "\\alpha") and will NOT match
+  // the regex /\\[A-Za-z]+/g used to find LaTeX commands in text.
+  const hasDoubleEscapedCommandKeys = /"\\\\\\\\[A-Za-z]+"\s*:/.test(text);
+  assert.strictEqual(
+    hasDoubleEscapedCommandKeys,
+    false,
+    'DEFAULT_COMMAND_MAP contains double-escaped keys like "\\\\alpha"; keys should match "\\alpha"'
+  );
+
+  const hasSingleEscapedCommandKey = /"\\\\[A-Za-z]+"\s*:/.test(text);
+  assert.strictEqual(
+    hasSingleEscapedCommandKey,
+    true,
+    'Expected DEFAULT_COMMAND_MAP to contain keys like "\\alpha"'
+  );
+}
+
+module.exports = {
+  name: 'unit/math-decorations-map',
+  run: () => {
+    testDefaultCommandMapKeysMatchCommandRegexOutput();
+  }
+};

--- a/org-vscode/test/unit/run.js
+++ b/org-vscode/test/unit/run.js
@@ -11,7 +11,8 @@ const tests = [
   require(path.join(__dirname, 'checkbox-cookie-toggle.test.js')),
   require(path.join(__dirname, 'checkbox-auto-done.test.js')),
   require(path.join(__dirname, 'checkbox-toggle.test.js')),
-  require(path.join(__dirname, 'smart-insert-new-element.test.js'))
+  require(path.join(__dirname, 'smart-insert-new-element.test.js')),
+  require(path.join(__dirname, 'math-decorations-map.test.js'))
 ];
 
 async function main() {


### PR DESCRIPTION
This PR prevents a regression where math symbol substitutions stop working if LaTeX command keys are accidentally double-escaped (e.g. \\\\alpha vs \\alpha).\n\n- Make lookup tolerant (try both key styles)\n- Add a unit regression test to catch double-escaped DEFAULT_COMMAND_MAP keys\n