### PR TITLE
Agenda/Tagged Agenda: click task to reveal source line

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Org-vscode helps you manage tasks, notes, and projects in plain text `.org` file
 - Selection-aware editing across multiple lines (status, schedule, deadline, tags, indentation)
 - v2 Org-mode alignment: `:TAGS:` at end of headline, planning lines under headings, `CLOSED:` stamp
 - TODO workflow: `TODO → IN_PROGRESS → CONTINUED → DONE/ABANDONED` (plus CONTINUED auto-forwarding)
-- Agenda View + Tagged Agenda View (Emacs-style match strings) + Calendar View
+- Agenda View + Tagged Agenda View (Emacs-style match strings) + Calendar View (click task text to jump to the exact source line)
 - Checklists with hierarchical parent/child checkbox states
 - Org-mode statistics cookies: `[/]` (fraction) and `[%]` (percent)
 - Subtree completion stats on headings (TODO subtree completion + checkbox completion)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # [Unreleased]
 
+- **Agenda View / Tagged Agenda:** Click task text (or filename) to reveal the exact source line in the editor. Settings: `Org-vscode.agendaRevealTaskOnClick` and `Org-vscode.agendaHighlightTaskOnClick`.
+
 # [2.2.1] 01-07-26
 `Fixed / Enhanced`
 

--- a/docs/howto.md
+++ b/docs/howto.md
@@ -317,6 +317,17 @@ You can open a file using either:
 
 The Agenda View shows only **TODO** and **IN_PROGRESS** tasks. Tasks marked as CONTINUED, DONE, or ABANDONED are excluded for a cleaner view of what still needs attention.
 
+### Click-to-navigate (Agenda + Tagged Agenda)
+
+You can click the **task text** (or the **filename**) to jump your cursor to the exact line in the source `.org` file.
+
+Optional settings:
+
+```json
+"Org-vscode.agendaRevealTaskOnClick": true,
+"Org-vscode.agendaHighlightTaskOnClick": true
+```
+
 <img src="https://github.com/realdestroyer/org-vscode/blob/master/Images/openAgenda.gif?raw=true" width="700" height="400" />
 
 ---
@@ -645,7 +656,8 @@ This lets you filter tasks across all files by tag(s). Two modes are supported:
 
 * Groups results by file
 * Shows each task with its current status, schedule date, and tags
-* Clickable filenames open the source
+* Clickable filenames open the source (or reveal the exact task line)
+* Clickable task text reveals the exact task line
 * Clickable status cycles through keywords
 * Use `[Expand All]` / `[Collapse All]` buttons to show/hide groups
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 ﻿# Roadmap
 
-Live version: 2.2.0
+Live version: 2.2.1
 
 These are the features that I have either already implemented, or plan to in the near future.
 
@@ -19,6 +19,7 @@ These are the features that I have either already implemented, or plan to in the
 | Preview (Live HTML) + scroll sync | Webview-based live preview with automatic refresh and editor → preview scroll sync | DONE | v2.2.0 | realDestroyer |
 | Org Meta-Return insert | `Alt+Enter` context-aware insert of heading / list item / table row | DONE | v2.2.0 | realDestroyer |
 | Math symbol decorations | Render common LaTeX commands (e.g. `\alpha`) as Unicode glyphs inside `$...$` / `$$...$$` | DONE | v2.2.0 | realDestroyer |
+| Agenda/Tagged Agenda click-to-reveal | Click task text (or filename) to reveal the exact source line; optional webview highlight | DONE | v2.2.2 | realDestroyer |
 | Property management commands | Set/update properties, auto-create drawers, and unique ID generation helpers | Not Started | v2.3.0 | realDestroyer |
 | Smart TAB folding behavior | Context-aware folding across headings/lists/blocks/properties (Emacs-style feel) | Not Started | v2.3.0 | realDestroyer |
 | Insert link utilities | Insert link command + richer link editing utilities | Not Started | v2.3.0 | realDestroyer |

--- a/org-vscode/out/taggedAgenda.js
+++ b/org-vscode/out/taggedAgenda.js
@@ -275,6 +275,25 @@ function showTaggedAgendaView(tag, items) {
       vscode.workspace.openTextDocument(vscode.Uri.file(filePath)).then(doc => {
         vscode.window.showTextDocument(doc, { preview: false });
       });
+    } else if (message.command === "revealTask") {
+      const fileName = String(message.file || "");
+      const lineNumber = Number(message.lineNumber);
+      if (!fileName || !Number.isFinite(lineNumber) || lineNumber < 1) {
+        return;
+      }
+
+      const orgDir = getOrgFolder();
+      const filePath = path.join(orgDir, fileName);
+      const uri = vscode.Uri.file(filePath);
+      vscode.workspace.openTextDocument(uri).then(doc => {
+        vscode.window.showTextDocument(doc, { preview: false }).then(editor => {
+          if (!editor) return;
+          const targetLine = Math.min(Math.max(0, lineNumber - 1), Math.max(0, doc.lineCount - 1));
+          const pos = new vscode.Position(targetLine, 0);
+          editor.selection = new vscode.Selection(pos, pos);
+          editor.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.InCenter);
+        });
+      });
     } else if (message.command === "changeStatus") {
       const parts = message.text.split(",");
       const newStatus = parts[0];
@@ -420,9 +439,9 @@ function getTaggedWebviewContent(webview, nonce, localMomentJs, tag, items) {
       return `
         <div class="panel ${file}">
           <div class="textDiv">
-            <span class="filename" data-file="${file}">${file}:</span>
+            <span class="filename" data-file="${file}" data-line="${item.lineNumber}">${file}:</span>
             <span class="${keywordClass}" data-filename="${file}" data-text="${taskText}" data-date="${scheduledDate}">${keyword}</span>
-            <span class="taskText">${taskText}</span>
+            <span class="taskText agenda-task-link" data-file="${file}" data-line="${item.lineNumber}">${taskText}</span>
             ${checkboxLabel}
             ${lateLabel}
             <span class="scheduled">SCHEDULED</span>
@@ -673,6 +692,16 @@ body{
           font-family: 'Roboto Mono', sans-serif;
           font-weight: 400;
         }
+
+        .agenda-task-link{
+          cursor: pointer;
+        }
+
+        .panel.agenda-selected{
+          outline: 2px solid #2f6999;
+          outline-offset: -2px;
+          background-color: rgba(47, 105, 153, 0.06);
+        }
         .checkbox-stats {
           float: left;
           margin-left: 10px;
@@ -758,6 +787,8 @@ body{
   <script nonce="${nonce}">
       const vscode = acquireVsCodeApi();
       const dateFormat = "${dateFormat}";
+      const revealTaskOnClick = ${config.get("agendaRevealTaskOnClick", true) ? "true" : "false"};
+      const highlightTaskOnClick = ${config.get("agendaHighlightTaskOnClick", true) ? "true" : "false"};
 
     // Initialize indeterminate display for partial checkboxes.
     Array.from(document.querySelectorAll('input.org-checkbox[data-state="partial"]'))
@@ -765,6 +796,25 @@ body{
 
       // Toggle file groups on file-tab click
       document.addEventListener('click', function(event) {
+          const revealEl = (event.target && event.target.closest)
+          ? event.target.closest('.agenda-task-link[data-file][data-line], .filename[data-file][data-line]')
+          : null;
+
+          if (revealEl && revealTaskOnClick) {
+            const file = revealEl.getAttribute('data-file');
+            const lineRaw = revealEl.getAttribute('data-line');
+            const lineNumber = lineRaw ? parseInt(lineRaw, 10) : NaN;
+            if (file && Number.isFinite(lineNumber)) {
+              vscode.postMessage({ command: 'revealTask', file, lineNumber });
+              if (highlightTaskOnClick) {
+                document.querySelectorAll('.panel.agenda-selected').forEach(p => p.classList.remove('agenda-selected'));
+                const panel = revealEl.closest('.panel');
+                if (panel) panel.classList.add('agenda-selected');
+              }
+              return;
+            }
+          }
+
           if (event.target && event.target.classList && event.target.classList.contains('org-checkbox')) {
               event.stopPropagation();
               const input = event.target;


### PR DESCRIPTION
Adds click-to-reveal navigation in Agenda View and Tagged Agenda View: clicking a task (or filename) jumps to the exact source line, with optional webview highlight.\n\nNew settings (default true):\n- Org-vscode.agendaRevealTaskOnClick\n- Org-vscode.agendaHighlightTaskOnClick\n\nDocs updated: README, howto, roadmap, changelog.\n\nTests: npm run test:unit, npm test