### PR TITLE
Fix Tagged Agenda selected row highlight

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # [Unreleased]
 
+`Fixed`
+
+- **Tagged Agenda:** Clicking a task (with highlight enabled) no longer applies a filled background to the selected row; it now matches Agenda View’s outline-only highlight. Disable via `Org-vscode.agendaHighlightTaskOnClick`.
+
 # [2.2.3] 01-11-26
 `Fixed`
 

--- a/org-vscode/out/taggedAgenda.js
+++ b/org-vscode/out/taggedAgenda.js
@@ -727,8 +727,7 @@ body{
 
         .panel.agenda-selected{
           outline: 2px solid #2f6999;
-          outline-offset: -2px;
-          background-color: rgba(47, 105, 153, 0.06);
+          outline-offset: 2px;
         }
         .checkbox-stats {
           float: left;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "org-vscode",
 	"displayName": "org-vscode",
 	"description": "Quickly create todo lists, take notes, plan projects and organize your thoughts.",
-	"version": "2.2.3",
+	"version": "2.2.4",
 	"repository": "https://www.github.com/realDestroyer/org-vscode",
 	"icon": "Images/org-vscode-logo.png",
 	"publisher": "realDestroyer",


### PR DESCRIPTION
Fixes #64.

- Remove filled background from Tagged Agenda selected row (outline-only, matches Agenda View)
- Bump version to 2.2.4 (unreleased)
- Add changelog entry under Unreleased

No publishing in this PR.