### PR TITLE
Fix syntax highlighting of TODO, IN_PROGRESS, SCHEDULED, DEADLINE, CL…

### DIFF
--- a/org-vscode/vso.tmLanguage.json
+++ b/org-vscode/vso.tmLanguage.json
@@ -677,40 +677,50 @@
     "task_text_todo": {
       "patterns": [
         {
-          "name": "string.task.todo.vso",
-          "match": "(?<=TODO\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)"
+          "match": "(?<=TODO)(\\s+)(.*?)(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)",
+          "captures": {
+            "2": { "name": "string.task.todo.vso" }
+          }
         }
       ]
     },
     "task_text_in_progress": {
       "patterns": [
         {
-          "name": "string.task.in_progress.vso",
-          "match": "(?<=IN_PROGRESS\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)"
+          "match": "(?<=IN_PROGRESS)(\\s+)(.*?)(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)",
+          "captures": {
+            "2": { "name": "string.task.in_progress.vso" }
+          }
         }
       ]
     },
     "task_text_done": {
       "patterns": [
         {
-          "name": "string.task.done.vso",
-          "match": "(?<=DONE\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)"
+          "match": "(?<=DONE)(\\s+)(.*?)(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)",
+          "captures": {
+            "2": { "name": "string.task.done.vso" }
+          }
         }
       ]
     },
     "task_text_abandoned": {
       "patterns": [
         {
-          "name": "string.task.abandoned.vso",
-          "match": "(?<=ABANDONED\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)"
+          "match": "(?<=ABANDONED)(\\s+)(.*?)(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)",
+          "captures": {
+            "2": { "name": "string.task.abandoned.vso" }
+          }
         }
       ]
     },
     "task_text_continued": {
       "patterns": [
         {
-          "name": "string.task.continued.vso",
-          "match": "(?<=CONTINUED\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)"
+          "match": "(?<=CONTINUED)(\\s+)(.*?)(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)",
+          "captures": {
+            "2": { "name": "string.task.continued.vso" }
+          }
         }
       ]
     },

--- a/vso.tmLanguage.json
+++ b/vso.tmLanguage.json
@@ -677,40 +677,50 @@
     "task_text_todo": {
       "patterns": [
         {
-          "name": "string.task.todo.vso",
-          "match": "(?<=TODO\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)"
+          "match": "(?<=TODO)(\\s+)(.*?)(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)",
+          "captures": {
+            "2": { "name": "string.task.todo.vso" }
+          }
         }
       ]
     },
     "task_text_in_progress": {
       "patterns": [
         {
-          "name": "string.task.in_progress.vso",
-          "match": "(?<=IN_PROGRESS\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)"
+          "match": "(?<=IN_PROGRESS)(\\s+)(.*?)(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)",
+          "captures": {
+            "2": { "name": "string.task.in_progress.vso" }
+          }
         }
       ]
     },
     "task_text_done": {
       "patterns": [
         {
-          "name": "string.task.done.vso",
-          "match": "(?<=DONE\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)"
+          "match": "(?<=DONE)(\\s+)(.*?)(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)",
+          "captures": {
+            "2": { "name": "string.task.done.vso" }
+          }
         }
       ]
     },
     "task_text_abandoned": {
       "patterns": [
         {
-          "name": "string.task.abandoned.vso",
-          "match": "(?<=ABANDONED\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)"
+          "match": "(?<=ABANDONED)(\\s+)(.*?)(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)",
+          "captures": {
+            "2": { "name": "string.task.abandoned.vso" }
+          }
         }
       ]
     },
     "task_text_continued": {
       "patterns": [
         {
-          "name": "string.task.continued.vso",
-          "match": "(?<=CONTINUED\\s+).*?(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)"
+          "match": "(?<=CONTINUED)(\\s+)(.*?)(?=(?:\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+(?=\\s+(?:SCHEDULED:|DEADLINE:|CLOSED:|COMPLETED:)))|(?:\\s+:(?:[A-Za-z0-9_@#%\\-]+:)+\\s*$)|$)",
+          "captures": {
+            "2": { "name": "string.task.continued.vso" }
+          }
         }
       ]
     },


### PR DESCRIPTION
…OSED, COMPLETED, DONE, ABANDONED.

Try on "Test"  on the following org text:

```
* TODO Test with ddd - future date
```

Before: Not detected correctly (not detected as vso)
After: Detected as string.task.todo.vso meta.task.todo.vso

See Ctrl-Shift-P Developer > Inspect Editor Tokens and Scopes. Correct output of that:

```
Test·with·ddd·-·future·date  27 chars
language	vso
standard token type	String
foreground	#0DBA30
background	#FDF6E3
contrast ratio	2.41
textmate scopes	string.task.todo.vso meta.task.todo.vso source.vso
foreground: string.task.todo.vso
```
