### PR TITLE
Docs + property/ID commands (2.2.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Org-vscode helps you manage tasks, notes, and projects in plain text `.org` file
 - Math symbol decorations (experimental): renders common LaTeX commands (e.g. `\alpha`) as Unicode glyphs while editing
 - Smart navigation helpers: Document Outline (headings) + clickable Org links (including `[[*heading]]`, `[[id:...]]`, `[[#target]]`, `file:`, `http(s)`, `mailto:`)
 - Org link auto-completion inside `[[...]]` (including workspace-wide `id:` suggestions)
+- Property drawer helpers: set/get/delete properties (with inheritance) + ID helpers (get-or-create, set/replace)
 - Org table generator (command + snippets)
 - Reports/tools: Export Current Tasks, Export Yearly Summary, Executive Report, Year-In-Review Dashboard
 - Customization: Syntax Color Customizer + settings for heading markers / indentation / decorations

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 # [Unreleased]
 
+`Added / Enhanced`
+
+- **Properties (Emacs parity):** Property drawer management commands:
+  - `Org-vscode: Set Property` (creates/updates drawers as needed)
+  - `Org-vscode: Get Property (with inheritance)` (local → parent headings → file `#+PROPERTY`)
+  - `Org-vscode: Delete Property` (removes empty drawers)
+- **IDs:**
+  - `Org-vscode: Get or Create ID` (creates a UUID when missing; copies to clipboard)
+  - `Org-vscode: Set ID` (sets/replaces ID; empty input generates a UUID; copies to clipboard)
+
 `Fixed`
 
 - **Tagged Agenda:** Clicking a task (with highlight enabled) no longer applies a filled background to the selected row; it now matches Agenda View’s outline-only highlight. Disable via `Org-vscode.agendaHighlightTaskOnClick`.

--- a/docs/howto.md
+++ b/docs/howto.md
@@ -62,6 +62,7 @@ VS Code Settings editor (search for `Org-vscode:`):
 * [🔖 Create a Header](#create-a-header)
 * [🧩 Org-vscode Snippets](#org-vscode-snippets)
 * [🔎 Org syntax + links](#org-syntax--links)
+* [🧾 Properties & IDs](#properties--ids)
 * [🪟 Preview (Live HTML)](#preview-live-html)
 * [∑ Math Symbol Decorations](#math-symbol-decorations)
 * [📂 Open a File by Tags or Titles](#open-a-file-by-tags-or-titles)
@@ -228,6 +229,59 @@ Examples:
 [[id:01234567-89ab-cdef-0123-456789abcdef]]
 [[#demo-anchor]]
 ```
+
+---
+
+## 🧾 Properties & IDs <a id="properties--ids"></a>
+
+Org-vscode supports Org-style property drawers and provides commands to manage properties without manual drawer editing.
+
+### Property drawers
+
+Property drawers use the canonical Org syntax:
+
+```org
+:PROPERTIES:
+:OWNER: Alice
+:CUSTOM_ID: demo-anchor
+:END:
+```
+
+### Commands
+
+- **Org-vscode: Set Property**
+  - Sets/updates a property on the nearest heading.
+  - Creates a `:PROPERTIES:` drawer if missing.
+- **Org-vscode: Get Property (with inheritance)**
+  - Looks up a property using Emacs-style precedence:
+    1) current heading drawer
+    2) parent heading drawers (nearest parent first)
+    3) file-level `#+PROPERTY` directives
+- **Org-vscode: Delete Property**
+  - Deletes a property from the nearest heading and removes the drawer if it becomes empty.
+
+### File-level properties (`#+PROPERTY`)
+
+You can define file defaults with:
+
+```org
+#+PROPERTY: OWNER Alice
+```
+
+These act as a fallback for `Get Property (with inheritance)` when the property isn’t found on the current heading or any parent heading.
+
+### IDs
+
+IDs are used for cross-file link navigation and completion via `[[id:...]]`.
+
+- **Org-vscode: Get or Create ID**
+  - Ensures the nearest heading has an `:ID:` property.
+  - Creates a UUID when missing.
+  - Copies the ID to your clipboard.
+- **Org-vscode: Set ID**
+  - Sets/replaces the `:ID:` property on the nearest heading.
+  - If you submit an empty input, it generates a UUID.
+  - Copies the resulting ID to your clipboard.
 
 #### `/checklist` <a id="checklist"></a>
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 ﻿# Roadmap
 
-Live version: 2.2.3
+Live version: 2.2.4
 
 These are the features that I have either already implemented, or plan to in the near future.
 
@@ -20,7 +20,7 @@ These are the features that I have either already implemented, or plan to in the
 | Org Meta-Return insert | `Alt+Enter` context-aware insert of heading / list item / table row | DONE | v2.2.0 | realDestroyer |
 | Math symbol decorations | Render common LaTeX commands (e.g. `\alpha`) as Unicode glyphs inside `$...$` / `$$...$$` | DONE | v2.2.0 | realDestroyer |
 | Agenda/Tagged Agenda click-to-reveal | Click task text (or filename) to reveal the exact source line; optional webview highlight | DONE | v2.2.2 | realDestroyer |
-| Property management commands | Set/update properties, auto-create drawers, and unique ID generation helpers | Not Started | v2.3.0 | realDestroyer |
+| Property management commands | Set/update properties, auto-create drawers, inherited lookup (local → parents → file `#+PROPERTY`), and ID helper commands | DONE | v2.2.4 | realDestroyer |
 | Smart TAB folding behavior | Context-aware folding across headings/lists/blocks/properties (Emacs-style feel) | Not Started | v2.3.0 | realDestroyer |
 | Insert link utilities | Insert link command + richer link editing utilities | Not Started | v2.3.0 | realDestroyer |
 | LaTeX fragment rendering (org-fragtog-style) | Render LaTeX fragments as “inline images” (full math fragment preview, not only symbol substitutions) | Not Started |  | realDestroyer |

--- a/examples/demo-walkthrough.org
+++ b/examples/demo-walkthrough.org
@@ -6,6 +6,9 @@
 # - Mutually exclusive groups: { GROUP : MEMBER1 MEMBER2 }
 #+TAGS: [ GTD : WORK HOME ] { CONTEXT : @WORK @HOME }
 
+# File-level properties (used as fallback for inherited lookups)
+#+PROPERTY: OWNER Demo Owner
+
 # This file is designed as a quick “tour” of Org-vscode.
 # Follow sections top-to-bottom for a demo video.
 # Lines starting with "#" are narration prompts.
@@ -211,6 +214,36 @@
 
   A classic Org target looks like this (link to it with [[#demo-target]]):
   <<demo-target>>
+
+* [2026-01-12 Mon] Properties + IDs (Commands) ---------------------------------------------------
+
+# 22a) Property and ID commands (Command Palette)
+# Commands:
+# - Org-vscode: Set Property
+# - Org-vscode: Get Property (with inheritance)
+# - Org-vscode: Delete Property
+# - Org-vscode: Get or Create ID
+# - Org-vscode: Set ID
+
+# 22b) Inheritance demo:
+# - This heading defines OWNER locally.
+# - The child heading inherits OWNER unless it overrides it.
+* TODO Parent property (OWNER=Parent) :PROPERTIES:
+  :OWNER: Parent
+  :END:
+
+** TODO Child inherits OWNER
+
+** TODO Child overrides OWNER :PROPERTIES:
+   :OWNER: Child
+   :END:
+
+# Try: run “Get Property (with inheritance)” on each heading for OWNER.
+# Also try “Delete Property” on the child override and re-run “Get Property”.
+
+# 22c) ID commands demo:
+# - Run “Get or Create ID” on a heading without an :ID: (it will add one and copy it).
+# - Run “Set ID” and paste a custom UUID (or submit empty input to auto-generate).
 
 # 23) Lists: ordered, unordered, and checkboxes
 * IN_PROGRESS List syntax demo :LISTS:

--- a/org-vscode/out/extension.js
+++ b/org-vscode/out/extension.js
@@ -62,6 +62,7 @@ const { insertCheckboxItem } = require("./insertCheckboxItem");
 const { toggleCheckboxCookie } = require("./toggleCheckboxCookie");
 const { toggleCheckboxItemAtCursor } = require("./toggleCheckboxItem");
 const { insertNewElement } = require("./smartInsertNewElement");
+const { registerPropertyCommands } = require("./propertyCommands");
 
 // Startup log for debugging
 console.log("📌 agenda.js has been loaded in extension.js");
@@ -173,6 +174,9 @@ function activate(ctx) {
 
   // Live preview webview (MVP) + editor -> preview scroll sync
   registerOrgPreview(ctx);
+
+  // Emacs-like property drawer commands (set/get/delete)
+  registerPropertyCommands(ctx);
 
   // Date format changes are not auto-applied to existing files because swapping
   // MM-DD and DD-MM can be ambiguous (e.g. 04-05-2026). Provide an explicit command instead.

--- a/org-vscode/out/orgProperties.js
+++ b/org-vscode/out/orgProperties.js
@@ -1,0 +1,364 @@
+"use strict";
+
+const { isPlanningLine } = require("./orgTagUtils");
+
+// Matches org headings in this extension's v2 style:
+// - optional unicode status prefix
+// - then one or more asterisks + whitespace
+const HEADING_LINE_REGEX = /^\s*(?:[⊙⊘⊜⊖⊗]\s*)?\*+\s+/;
+
+const PROPERTY_DRAWER_BEGIN_RE = /^\s*:PROPERTIES:\s*$/i;
+const DRAWER_END_RE = /^\s*:END:\s*$/i;
+
+// File-level property, e.g.:
+// #+PROPERTY: CATEGORY Work
+// #+PROPERTY: Effort 0:30
+const FILE_PROPERTY_RE = /^\s*#\+PROPERTY:\s*([A-Za-z0-9_@#%\-]+)\s*(.*?)\s*$/i;
+
+// Capture groups:
+// 1) indent
+// 2) key
+// 3) value
+const PROPERTY_LINE_RE = /^(\s*):([A-Za-z0-9_@#%\-]+):\s*(.*?)\s*$/;
+
+function isHeadingLine(text) {
+  return HEADING_LINE_REGEX.test(String(text || ""));
+}
+
+function getHeadingLevel(lineText) {
+  const m = String(lineText || "").match(/^\s*(?:[⊙⊘⊜⊖⊗]\s*)?(\*+)\s+/);
+  return m ? m[1].length : null;
+}
+
+function findNearestHeadingLine(lines, fromLine) {
+  for (let i = Math.max(0, fromLine); i >= 0; i--) {
+    if (isHeadingLine(lines[i])) return i;
+  }
+  return null;
+}
+
+function getHeadingIndent(lineText) {
+  return String(lineText || "").match(/^\s*/)?.[0] || "";
+}
+
+function normalizePropertyKey(key) {
+  return String(key || "").trim().toUpperCase();
+}
+
+function parseFileProperties(lines) {
+  const props = new Map();
+  for (const line of lines) {
+    const m = String(line || "").match(FILE_PROPERTY_RE);
+    if (!m) continue;
+
+    const key = normalizePropertyKey(m[1]);
+    if (!key) continue;
+
+    const value = (m[2] || "").trim();
+    // If multiple #+PROPERTY lines exist for same key, last one wins.
+    props.set(key, value);
+  }
+  return props;
+}
+
+function findParentHeadingLineIndices(lines, headingLineIndex) {
+  const parents = [];
+  if (headingLineIndex == null || headingLineIndex < 0 || headingLineIndex >= lines.length) return parents;
+
+  let currentLevel = getHeadingLevel(lines[headingLineIndex]);
+  if (currentLevel == null) return parents;
+
+  let searchFrom = headingLineIndex - 1;
+  while (searchFrom >= 0) {
+    let found = false;
+    for (let i = searchFrom; i >= 0; i--) {
+      const level = getHeadingLevel(lines[i]);
+      if (level == null) continue;
+      if (level < currentLevel) {
+        parents.push(i);
+        currentLevel = level;
+        searchFrom = i - 1;
+        found = true;
+        break;
+      }
+    }
+    if (!found) break;
+  }
+
+  return parents;
+}
+
+function isDrawerBegin(text) {
+  return PROPERTY_DRAWER_BEGIN_RE.test(String(text || ""));
+}
+
+function isDrawerEnd(text) {
+  return DRAWER_END_RE.test(String(text || ""));
+}
+
+function findPropertyDrawerRange(lines, headingLineIndex) {
+  if (headingLineIndex == null || headingLineIndex < 0 || headingLineIndex >= lines.length) {
+    return null;
+  }
+
+  let i = headingLineIndex + 1;
+
+  // Skip consecutive planning lines directly under the heading.
+  while (i < lines.length && isPlanningLine(lines[i])) {
+    i++;
+  }
+
+  // Only treat a drawer as "the heading's property drawer" if it appears immediately
+  // at the top of the entry (after optional planning lines). If we hit content or a
+  // new heading first, abort.
+  while (i < lines.length) {
+    const t = lines[i];
+
+    if (isDrawerBegin(t)) {
+      const beginLine = i;
+      let endLine = null;
+      for (let j = i + 1; j < lines.length; j++) {
+        if (isDrawerEnd(lines[j])) {
+          endLine = j;
+          break;
+        }
+      }
+      if (endLine == null) return null;
+      return { beginLine, endLine };
+    }
+
+    if (!String(t || "").trim()) {
+      // If the entry begins with blank lines, allow drawer right after.
+      i++;
+      continue;
+    }
+
+    if (isHeadingLine(t)) {
+      return null;
+    }
+
+    // First non-blank, non-drawer content means no property drawer at the top.
+    return null;
+  }
+
+  return null;
+}
+
+function parsePropertyDrawer(lines, headingLineIndex) {
+  const range = findPropertyDrawerRange(lines, headingLineIndex);
+  if (!range) {
+    return { range: null, properties: new Map(), indent: null, keyLineMap: new Map() };
+  }
+
+  const beginText = lines[range.beginLine] || "";
+  const indent = beginText.match(/^\s*/)?.[0] || "";
+
+  const properties = new Map();
+  const keyLineMap = new Map();
+
+  for (let i = range.beginLine + 1; i < range.endLine; i++) {
+    const m = (lines[i] || "").match(PROPERTY_LINE_RE);
+    if (!m) continue;
+
+    const rawKey = m[2];
+    const key = normalizePropertyKey(rawKey);
+
+    // Ignore drawer markers accidentally matched as properties.
+    if (key === "PROPERTIES" || key === "END") continue;
+
+    const value = m[3] || "";
+    properties.set(key, value);
+    keyLineMap.set(key, i);
+  }
+
+  return { range, properties, indent, keyLineMap };
+}
+
+function computeInsertionLineAfterPlanning(lines, headingLineIndex) {
+  let i = headingLineIndex + 1;
+  while (i < lines.length && isPlanningLine(lines[i])) i++;
+  return i;
+}
+
+function setPropertyInLines(lines, headingLineIndex, key, value) {
+  const normalizedKey = normalizePropertyKey(key);
+  const normalizedValue = String(value ?? "");
+
+  if (!normalizedKey) {
+    return { lines, changed: false };
+  }
+
+  const nextLines = lines.slice();
+
+  const parsed = parsePropertyDrawer(nextLines, headingLineIndex);
+
+  // 1) Existing drawer + property line: replace
+  if (parsed.range && parsed.keyLineMap.has(normalizedKey)) {
+    const lineIndex = parsed.keyLineMap.get(normalizedKey);
+    const existingLine = nextLines[lineIndex] || "";
+    const indent = existingLine.match(/^\s*/)?.[0] || parsed.indent || "";
+
+    const newLine = normalizedValue.trim().length
+      ? `${indent}:${normalizedKey}: ${normalizedValue}`
+      : `${indent}:${normalizedKey}:`;
+
+    if (newLine !== existingLine) {
+      nextLines[lineIndex] = newLine;
+      return { lines: nextLines, changed: true };
+    }
+
+    return { lines: nextLines, changed: false };
+  }
+
+  // 2) Existing drawer but missing property: insert before :END:
+  if (parsed.range) {
+    const indent = parsed.indent || getHeadingIndent(nextLines[headingLineIndex]) + "  ";
+    const newLine = normalizedValue.trim().length
+      ? `${indent}:${normalizedKey}: ${normalizedValue}`
+      : `${indent}:${normalizedKey}:`;
+
+    nextLines.splice(parsed.range.endLine, 0, newLine);
+    return { lines: nextLines, changed: true };
+  }
+
+  // 3) No drawer: insert a new drawer block at top of entry
+  const headingIndent = getHeadingIndent(nextLines[headingLineIndex]);
+  const drawerIndent = `${headingIndent}  `;
+
+  const insertAt = computeInsertionLineAfterPlanning(nextLines, headingLineIndex);
+  const block = [
+    `${drawerIndent}:PROPERTIES:`,
+    normalizedValue.trim().length
+      ? `${drawerIndent}:${normalizedKey}: ${normalizedValue}`
+      : `${drawerIndent}:${normalizedKey}:`,
+    `${drawerIndent}:END:`
+  ];
+
+  nextLines.splice(insertAt, 0, ...block);
+  return { lines: nextLines, changed: true };
+}
+
+function deletePropertyInLines(lines, headingLineIndex, key) {
+  const normalizedKey = normalizePropertyKey(key);
+  if (!normalizedKey) return { lines, changed: false, removedDrawer: false };
+
+  const nextLines = lines.slice();
+  const parsed = parsePropertyDrawer(nextLines, headingLineIndex);
+  if (!parsed.range) return { lines: nextLines, changed: false, removedDrawer: false };
+
+  const lineIndex = parsed.keyLineMap.get(normalizedKey);
+  if (lineIndex == null) return { lines: nextLines, changed: false, removedDrawer: false };
+
+  nextLines.splice(lineIndex, 1);
+
+  // Re-parse to see if drawer is now empty (no properties between markers).
+  const reparsed = parsePropertyDrawer(nextLines, headingLineIndex);
+  let hasAny = false;
+  if (reparsed.range) {
+    for (let i = reparsed.range.beginLine + 1; i < reparsed.range.endLine; i++) {
+      const m = (nextLines[i] || "").match(PROPERTY_LINE_RE);
+      if (m) {
+        const k = normalizePropertyKey(m[2]);
+        if (k !== "PROPERTIES" && k !== "END") {
+          hasAny = true;
+          break;
+        }
+      }
+    }
+  }
+
+  if (!hasAny && reparsed.range) {
+    // Remove entire drawer marker block.
+    const count = reparsed.range.endLine - reparsed.range.beginLine + 1;
+    nextLines.splice(reparsed.range.beginLine, count);
+    return { lines: nextLines, changed: true, removedDrawer: true };
+  }
+
+  return { lines: nextLines, changed: true, removedDrawer: false };
+}
+
+function getPropertyFromLines(lines, headingLineIndex, key) {
+  const normalizedKey = normalizePropertyKey(key);
+  if (!normalizedKey) return null;
+
+  const parsed = parsePropertyDrawer(lines, headingLineIndex);
+  return parsed.properties.get(normalizedKey) ?? null;
+}
+
+function getPropertyFromLinesWithInheritance(lines, headingLineIndex, key) {
+  const normalizedKey = normalizePropertyKey(key);
+  if (!normalizedKey) return null;
+
+  // 1) Current entry
+  const local = getPropertyFromLines(lines, headingLineIndex, normalizedKey);
+  if (local != null) return local;
+
+  // 2) Parent headings (closest first)
+  const parents = findParentHeadingLineIndices(lines, headingLineIndex);
+  for (const parentIndex of parents) {
+    const v = getPropertyFromLines(lines, parentIndex, normalizedKey);
+    if (v != null) return v;
+  }
+
+  // 3) File-level defaults
+  const fileProps = parseFileProperties(lines);
+  return fileProps.get(normalizedKey) ?? null;
+}
+
+function getAllPropertyKeysWithInheritance(lines, headingLineIndex) {
+  const keys = new Set();
+
+  // current
+  const current = parsePropertyDrawer(lines, headingLineIndex);
+  for (const k of current.properties.keys()) keys.add(k);
+
+  // parents
+  const parents = findParentHeadingLineIndices(lines, headingLineIndex);
+  for (const parentIndex of parents) {
+    const parsed = parsePropertyDrawer(lines, parentIndex);
+    for (const k of parsed.properties.keys()) keys.add(k);
+  }
+
+  // file
+  const fileProps = parseFileProperties(lines);
+  for (const k of fileProps.keys()) keys.add(k);
+
+  return Array.from(keys);
+}
+
+function ensureIdInLines(lines, headingLineIndex, generateId) {
+  const existing = getPropertyFromLines(lines, headingLineIndex, "ID");
+  if (existing != null && String(existing).trim().length) {
+    return { id: String(existing), lines: lines.slice(), changed: false };
+  }
+
+  const id = typeof generateId === "function" ? String(generateId()) : "";
+  if (!id.trim()) {
+    return { id: null, lines: lines.slice(), changed: false };
+  }
+
+  const result = setPropertyInLines(lines, headingLineIndex, "ID", id);
+  return { id, lines: result.lines, changed: result.changed };
+}
+
+module.exports = {
+  HEADING_LINE_REGEX,
+  PROPERTY_DRAWER_BEGIN_RE,
+  DRAWER_END_RE,
+  PROPERTY_LINE_RE,
+  FILE_PROPERTY_RE,
+  isHeadingLine,
+  getHeadingLevel,
+  findNearestHeadingLine,
+  findParentHeadingLineIndices,
+  parseFileProperties,
+  findPropertyDrawerRange,
+  parsePropertyDrawer,
+  setPropertyInLines,
+  deletePropertyInLines,
+  getPropertyFromLines,
+  getPropertyFromLinesWithInheritance,
+  getAllPropertyKeysWithInheritance,
+  ensureIdInLines,
+  normalizePropertyKey
+};

--- a/org-vscode/out/propertyCommands.js
+++ b/org-vscode/out/propertyCommands.js
@@ -1,0 +1,263 @@
+"use strict";
+
+const vscode = require("vscode");
+const crypto = require("crypto");
+const {
+  findNearestHeadingLine,
+  setPropertyInLines,
+  deletePropertyInLines,
+  getPropertyFromLines,
+  getPropertyFromLinesWithInheritance,
+  getAllPropertyKeysWithInheritance,
+  ensureIdInLines,
+  parsePropertyDrawer,
+  normalizePropertyKey
+} = require("./orgProperties");
+
+function isOrgLikeDocument(document) {
+  const id = document?.languageId;
+  return id === "vso" || id === "org" || id === "vsorg" || id === "org-vscode";
+}
+
+function getDocumentTextLines(document) {
+  return document.getText().split(/\r?\n/);
+}
+
+function getDocumentEol(document) {
+  return document.eol === vscode.EndOfLine.CRLF ? "\r\n" : "\n";
+}
+
+function replaceWholeDocument(document, newText) {
+  const lastLine = Math.max(0, document.lineCount - 1);
+  const lastChar = document.lineAt(lastLine).text.length;
+  const fullRange = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(lastLine, lastChar));
+
+  const edit = new vscode.WorkspaceEdit();
+  edit.replace(document.uri, fullRange, newText);
+  return vscode.workspace.applyEdit(edit);
+}
+
+function generateUuid() {
+  if (typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  const bytes = crypto.randomBytes(16);
+  // v4
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = bytes.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+async function setPropertyCommand() {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || !isOrgLikeDocument(editor.document)) return;
+
+  const document = editor.document;
+  const lines = getDocumentTextLines(document);
+
+  const headingLineIndex = findNearestHeadingLine(lines, editor.selection.active.line);
+  if (headingLineIndex == null) {
+    vscode.window.showWarningMessage("Org-vscode: No heading found above cursor.");
+    return;
+  }
+
+  const parsed = parsePropertyDrawer(lines, headingLineIndex);
+  const existingKeys = Array.from(parsed.properties.keys()).sort();
+
+  const keyInput = await vscode.window.showInputBox({
+    prompt: "Org-vscode: Property name (e.g. CUSTOM_ID, ID, CATEGORY)",
+    placeHolder: existingKeys.length ? `Existing: ${existingKeys.slice(0, 6).join(", ")}${existingKeys.length > 6 ? ", ..." : ""}` : "CUSTOM_ID"
+  });
+
+  if (keyInput == null) return;
+  const key = normalizePropertyKey(keyInput);
+  if (!key) {
+    vscode.window.showWarningMessage("Org-vscode: Property name is required.");
+    return;
+  }
+
+  const currentValue = getPropertyFromLines(lines, headingLineIndex, key);
+  const value = await vscode.window.showInputBox({
+    prompt: `Org-vscode: Value for ${key} (leave empty to set blank)`,
+    value: currentValue ?? "",
+    placeHolder: "Example: my-heading-anchor"
+  });
+
+  if (value == null) return;
+
+  const result = setPropertyInLines(lines, headingLineIndex, key, value);
+  if (!result.changed) return;
+
+  const eol = getDocumentEol(document);
+  const hadFinalNewline = document.getText().endsWith("\n");
+  let newText = result.lines.join(eol);
+  if (hadFinalNewline && !newText.endsWith(eol)) newText += eol;
+
+  await replaceWholeDocument(document, newText);
+}
+
+async function deletePropertyCommand() {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || !isOrgLikeDocument(editor.document)) return;
+
+  const document = editor.document;
+  const lines = getDocumentTextLines(document);
+
+  const headingLineIndex = findNearestHeadingLine(lines, editor.selection.active.line);
+  if (headingLineIndex == null) {
+    vscode.window.showWarningMessage("Org-vscode: No heading found above cursor.");
+    return;
+  }
+
+  const parsed = parsePropertyDrawer(lines, headingLineIndex);
+  const existingKeys = Array.from(parsed.properties.keys()).sort();
+  if (!parsed.range) {
+    vscode.window.showWarningMessage("Org-vscode: No property drawer found for this heading.");
+    return;
+  }
+
+  const pick = existingKeys.length
+    ? await vscode.window.showQuickPick(existingKeys, { placeHolder: "Select a property to delete" })
+    : await vscode.window.showInputBox({ prompt: "Org-vscode: Property name to delete" });
+
+  if (pick == null) return;
+  const key = normalizePropertyKey(pick);
+  if (!key) return;
+
+  const result = deletePropertyInLines(lines, headingLineIndex, key);
+  if (!result.changed) {
+    vscode.window.showInformationMessage(`Org-vscode: Property ${key} not found.`);
+    return;
+  }
+
+  const eol = getDocumentEol(document);
+  const hadFinalNewline = document.getText().endsWith("\n");
+  let newText = result.lines.join(eol);
+  if (hadFinalNewline && !newText.endsWith(eol)) newText += eol;
+
+  await replaceWholeDocument(document, newText);
+}
+
+async function getPropertyCommand() {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || !isOrgLikeDocument(editor.document)) return;
+
+  const document = editor.document;
+  const lines = getDocumentTextLines(document);
+
+  const headingLineIndex = findNearestHeadingLine(lines, editor.selection.active.line);
+  if (headingLineIndex == null) {
+    vscode.window.showWarningMessage("Org-vscode: No heading found above cursor.");
+    return;
+  }
+
+  const existingKeys = getAllPropertyKeysWithInheritance(lines, headingLineIndex).sort();
+
+  const keyInput = existingKeys.length
+    ? await vscode.window.showQuickPick(existingKeys, { placeHolder: "Select a property" })
+    : await vscode.window.showInputBox({ prompt: "Org-vscode: Property name" });
+
+  if (keyInput == null) return;
+  const key = normalizePropertyKey(keyInput);
+  if (!key) return;
+
+  const value = getPropertyFromLinesWithInheritance(lines, headingLineIndex, key);
+  if (value == null) {
+    vscode.window.showInformationMessage(`Org-vscode: ${key} is not set.`);
+    return;
+  }
+
+  await vscode.env.clipboard.writeText(String(value));
+  vscode.window.showInformationMessage(`Org-vscode: ${key} = ${value} (copied to clipboard)`);
+}
+
+async function setIdCommand() {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || !isOrgLikeDocument(editor.document)) return;
+
+  const document = editor.document;
+  const lines = getDocumentTextLines(document);
+
+  const headingLineIndex = findNearestHeadingLine(lines, editor.selection.active.line);
+  if (headingLineIndex == null) {
+    vscode.window.showWarningMessage("Org-vscode: No heading found above cursor.");
+    return;
+  }
+
+  const localId = getPropertyFromLines(lines, headingLineIndex, "ID");
+  const inheritedId = getPropertyFromLinesWithInheritance(lines, headingLineIndex, "ID");
+
+  const idInput = await vscode.window.showInputBox({
+    prompt: "Org-vscode: Set ID for this heading (empty = generate new UUID)",
+    value: localId ?? "",
+    placeHolder: inheritedId ? `Inherited/Current: ${inheritedId}` : "e.g. 550e8400-e29b-41d4-a716-446655440000"
+  });
+
+  if (idInput == null) return;
+
+  const id = String(idInput).trim() ? String(idInput).trim() : generateUuid();
+  const result = setPropertyInLines(lines, headingLineIndex, "ID", id);
+  if (!result.changed) {
+    await vscode.env.clipboard.writeText(String(id));
+    vscode.window.showInformationMessage(`Org-vscode: ID unchanged (${id}) (copied to clipboard)`);
+    return;
+  }
+
+  const eol = getDocumentEol(document);
+  const hadFinalNewline = document.getText().endsWith("\n");
+  let newText = result.lines.join(eol);
+  if (hadFinalNewline && !newText.endsWith(eol)) newText += eol;
+
+  await replaceWholeDocument(document, newText);
+  await vscode.env.clipboard.writeText(String(id));
+  vscode.window.showInformationMessage(`Org-vscode: Set ID = ${id} (copied to clipboard)`);
+}
+
+async function getOrCreateIdCommand() {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || !isOrgLikeDocument(editor.document)) return;
+
+  const document = editor.document;
+  const lines = getDocumentTextLines(document);
+
+  const headingLineIndex = findNearestHeadingLine(lines, editor.selection.active.line);
+  if (headingLineIndex == null) {
+    vscode.window.showWarningMessage("Org-vscode: No heading found above cursor.");
+    return;
+  }
+
+  const ensured = ensureIdInLines(lines, headingLineIndex, generateUuid);
+  if (!ensured.id) {
+    vscode.window.showErrorMessage("Org-vscode: Failed to generate an ID.");
+    return;
+  }
+
+  if (ensured.changed) {
+    const eol = getDocumentEol(document);
+    const hadFinalNewline = document.getText().endsWith("\n");
+    let newText = ensured.lines.join(eol);
+    if (hadFinalNewline && !newText.endsWith(eol)) newText += eol;
+    await replaceWholeDocument(document, newText);
+  }
+
+  await vscode.env.clipboard.writeText(String(ensured.id));
+  vscode.window.showInformationMessage(
+    ensured.changed
+      ? `Org-vscode: Created ID = ${ensured.id} (copied to clipboard)`
+      : `Org-vscode: ID = ${ensured.id} (copied to clipboard)`
+  );
+}
+
+function registerPropertyCommands(ctx) {
+  ctx.subscriptions.push(vscode.commands.registerCommand("org-vscode.setProperty", setPropertyCommand));
+  ctx.subscriptions.push(vscode.commands.registerCommand("org-vscode.deleteProperty", deletePropertyCommand));
+  ctx.subscriptions.push(vscode.commands.registerCommand("org-vscode.getProperty", getPropertyCommand));
+  ctx.subscriptions.push(vscode.commands.registerCommand("org-vscode.setId", setIdCommand));
+  ctx.subscriptions.push(vscode.commands.registerCommand("org-vscode.getOrCreateId", getOrCreateIdCommand));
+}
+
+module.exports = {
+  registerPropertyCommands
+};

--- a/org-vscode/test/unit/org-properties.test.js
+++ b/org-vscode/test/unit/org-properties.test.js
@@ -1,0 +1,244 @@
+const assert = require('assert');
+const path = require('path');
+
+const {
+  findNearestHeadingLine,
+  setPropertyInLines,
+  deletePropertyInLines,
+  getPropertyFromLines,
+  getPropertyFromLinesWithInheritance,
+  ensureIdInLines
+} = require(path.join(__dirname, '..', '..', 'out', 'orgProperties.js'));
+
+function testInsertsNewDrawerUnderHeading() {
+  const lines = [
+    '* TODO Heading',
+    'Some body text'
+  ];
+
+  const heading = findNearestHeadingLine(lines, 0);
+  assert.strictEqual(heading, 0);
+
+  const res = setPropertyInLines(lines, heading, 'CUSTOM_ID', 'abc');
+  assert.strictEqual(res.changed, true);
+
+  assert.deepStrictEqual(res.lines, [
+    '* TODO Heading',
+    '  :PROPERTIES:',
+    '  :CUSTOM_ID: abc',
+    '  :END:',
+    'Some body text'
+  ]);
+}
+
+function testInsertsDrawerAfterPlanningLines() {
+  const lines = [
+    '* TODO Heading',
+    '  SCHEDULED: [2026-01-01 Thu]',
+    'Body'
+  ];
+
+  const heading = findNearestHeadingLine(lines, 2);
+  assert.strictEqual(heading, 0);
+
+  const res = setPropertyInLines(lines, heading, 'CATEGORY', 'Work');
+  assert.strictEqual(res.changed, true);
+
+  assert.deepStrictEqual(res.lines, [
+    '* TODO Heading',
+    '  SCHEDULED: [2026-01-01 Thu]',
+    '  :PROPERTIES:',
+    '  :CATEGORY: Work',
+    '  :END:',
+    'Body'
+  ]);
+}
+
+function testUpdatesExistingPropertyValue() {
+  const lines = [
+    '* Heading',
+    '  :PROPERTIES:',
+    '  :CUSTOM_ID: old',
+    '  :END:',
+    'Text'
+  ];
+
+  const res = setPropertyInLines(lines, 0, 'custom_id', 'new');
+  assert.strictEqual(res.changed, true);
+  assert.strictEqual(res.lines[2], '  :CUSTOM_ID: new');
+}
+
+function testAddsPropertyIntoExistingDrawer() {
+  const lines = [
+    '* Heading',
+    '  :PROPERTIES:',
+    '  :CUSTOM_ID: abc',
+    '  :END:',
+    'Text'
+  ];
+
+  const res = setPropertyInLines(lines, 0, 'CATEGORY', 'Work');
+  assert.strictEqual(res.changed, true);
+
+  assert.deepStrictEqual(res.lines, [
+    '* Heading',
+    '  :PROPERTIES:',
+    '  :CUSTOM_ID: abc',
+    '  :CATEGORY: Work',
+    '  :END:',
+    'Text'
+  ]);
+}
+
+function testDeletesPropertyKeepsDrawerIfOthersRemain() {
+  const lines = [
+    '* Heading',
+    '  :PROPERTIES:',
+    '  :CUSTOM_ID: abc',
+    '  :CATEGORY: Work',
+    '  :END:',
+    'Text'
+  ];
+
+  const res = deletePropertyInLines(lines, 0, 'CUSTOM_ID');
+  assert.strictEqual(res.changed, true);
+  assert.strictEqual(res.removedDrawer, false);
+
+  assert.deepStrictEqual(res.lines, [
+    '* Heading',
+    '  :PROPERTIES:',
+    '  :CATEGORY: Work',
+    '  :END:',
+    'Text'
+  ]);
+}
+
+function testDeletesDrawerIfBecomesEmpty() {
+  const lines = [
+    '* Heading',
+    '  :PROPERTIES:',
+    '  :CUSTOM_ID: abc',
+    '  :END:',
+    'Text'
+  ];
+
+  const res = deletePropertyInLines(lines, 0, 'CUSTOM_ID');
+  assert.strictEqual(res.changed, true);
+  assert.strictEqual(res.removedDrawer, true);
+
+  assert.deepStrictEqual(res.lines, [
+    '* Heading',
+    'Text'
+  ]);
+}
+
+function testGetsPropertyValue() {
+  const lines = [
+    '* Heading',
+    '  :PROPERTIES:',
+    '  :CATEGORY: Work',
+    '  :END:'
+  ];
+
+  const v = getPropertyFromLines(lines, 0, 'category');
+  assert.strictEqual(v, 'Work');
+}
+
+function testInheritsFromParentDrawer() {
+  const lines = [
+    '* Parent',
+    '  :PROPERTIES:',
+    '  :CATEGORY: Work',
+    '  :END:',
+    '** Child'
+  ];
+
+  const v = getPropertyFromLinesWithInheritance(lines, 4, 'CATEGORY');
+  assert.strictEqual(v, 'Work');
+}
+
+function testChildOverridesParent() {
+  const lines = [
+    '* Parent',
+    '  :PROPERTIES:',
+    '  :CATEGORY: Work',
+    '  :END:',
+    '** Child',
+    '   :PROPERTIES:',
+    '   :CATEGORY: Personal',
+    '   :END:'
+  ];
+
+  const v = getPropertyFromLinesWithInheritance(lines, 4, 'CATEGORY');
+  assert.strictEqual(v, 'Personal');
+}
+
+function testInheritsFromFilePropertyWhenNoLocalOrParent() {
+  const lines = [
+    '#+PROPERTY: CATEGORY Home',
+    '* Parent',
+    '** Child'
+  ];
+
+  const v = getPropertyFromLinesWithInheritance(lines, 2, 'CATEGORY');
+  assert.strictEqual(v, 'Home');
+}
+
+function testParentOverridesFileProperty() {
+  const lines = [
+    '#+PROPERTY: CATEGORY Home',
+    '* Parent',
+    '  :PROPERTIES:',
+    '  :CATEGORY: Work',
+    '  :END:',
+    '** Child'
+  ];
+
+  const v = getPropertyFromLinesWithInheritance(lines, 5, 'CATEGORY');
+  assert.strictEqual(v, 'Work');
+}
+
+function testEnsureIdCreatesIfMissing() {
+  const lines = [
+    '* Heading'
+  ];
+
+  const ensured = ensureIdInLines(lines, 0, () => 'abc-123');
+  assert.strictEqual(ensured.changed, true);
+  assert.strictEqual(ensured.id, 'abc-123');
+
+  // Should now have a property drawer with :ID:
+  assert.ok(ensured.lines.some((l) => l.includes(':ID: abc-123')));
+}
+
+function testEnsureIdDoesNotOverwriteExisting() {
+  const lines = [
+    '* Heading',
+    '  :PROPERTIES:',
+    '  :ID: keep-me',
+    '  :END:'
+  ];
+
+  const ensured = ensureIdInLines(lines, 0, () => 'new-id');
+  assert.strictEqual(ensured.changed, false);
+  assert.strictEqual(ensured.id, 'keep-me');
+}
+
+module.exports = {
+  name: 'unit/org-properties',
+  run: () => {
+    testInsertsNewDrawerUnderHeading();
+    testInsertsDrawerAfterPlanningLines();
+    testUpdatesExistingPropertyValue();
+    testAddsPropertyIntoExistingDrawer();
+    testDeletesPropertyKeepsDrawerIfOthersRemain();
+    testDeletesDrawerIfBecomesEmpty();
+    testGetsPropertyValue();
+    testInheritsFromParentDrawer();
+    testChildOverridesParent();
+    testInheritsFromFilePropertyWhenNoLocalOrParent();
+    testParentOverridesFileProperty();
+    testEnsureIdCreatesIfMissing();
+    testEnsureIdDoesNotOverwriteExisting();
+  }
+};

--- a/org-vscode/test/unit/run.js
+++ b/org-vscode/test/unit/run.js
@@ -11,6 +11,7 @@ const tests = [
   require(path.join(__dirname, 'checkbox-cookie-toggle.test.js')),
   require(path.join(__dirname, 'checkbox-auto-done.test.js')),
   require(path.join(__dirname, 'checkbox-toggle.test.js')),
+  require(path.join(__dirname, 'org-properties.test.js')),
   require(path.join(__dirname, 'smart-insert-new-element.test.js')),
   require(path.join(__dirname, 'math-decorations-map.test.js')),
   require(path.join(__dirname, 'date-parsing.test.js')),

--- a/package.json
+++ b/package.json
@@ -366,6 +366,31 @@
 				"title": "Insert New Element (Smart)"
 			},
 			{
+				"command": "org-vscode.setProperty",
+				"category": "Org-vscode",
+				"title": "Set Property"
+			},
+			{
+				"command": "org-vscode.getProperty",
+				"category": "Org-vscode",
+				"title": "Get Property (with inheritance)"
+			},
+			{
+				"command": "org-vscode.deleteProperty",
+				"category": "Org-vscode",
+				"title": "Delete Property"
+			},
+			{
+				"command": "org-vscode.setId",
+				"category": "Org-vscode",
+				"title": "Set ID"
+			},
+			{
+				"command": "org-vscode.getOrCreateId",
+				"category": "Org-vscode",
+				"title": "Get or Create ID"
+			},
+			{
 				"command": "extension.migrateFileToV2",
 				"category": "Org-vscode",
 				"title": "Migrate File to v2 Format"


### PR DESCRIPTION
Adds Emacs-style property drawer utilities and ID helpers, plus documentation updates.

- Commands: Set Property, Get Property (with inheritance), Delete Property
- ID workflows: Get or Create ID; Set ID (replace / auto-generate)
- Docs: howto + changelog + roadmap + README + demo walkthrough

After merge: finalize 2.2.4 release commit, package VSIX, publish to VS Marketplace + Open VSX, and upload VSIX to GitHub Releases.