### PR TITLE
Syntax Color Customizer: Property Drawer scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Org-vscode helps you manage tasks, notes, and projects in plain text `.org` file
 - Property drawer helpers: set/get/delete properties (with inheritance) + ID helpers (get-or-create, set/replace)
 - Org table generator (command + snippets)
 - Reports/tools: Export Current Tasks, Export Yearly Summary, Executive Report, Year-In-Review Dashboard
-- Customization: Syntax Color Customizer + settings for heading markers / indentation / decorations
+- Customization: Syntax Color Customizer (including property drawers) + settings for heading markers / indentation / decorations
 
 See every feature in one file:
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 # [Unreleased]
 
-(No entries yet.)
+`Enhanced`
+
+- **Syntax Color Customizer:** Added a `Property Drawer` control (scope: `meta.block.property.vso`) so you can style `:PROPERTIES:`…`:END:` blocks.
 
 # [2.2.4] 01-11-26
 

--- a/docs/howto.md
+++ b/docs/howto.md
@@ -838,7 +838,7 @@ Elements are grouped for easy navigation:
 * **CONTINUED Tasks** - Symbol, keyword, and task text
 * **DONE Tasks** - Symbol, keyword, and task text
 * **ABANDONED Tasks** - Symbol, keyword, and task text
-* **Other Elements** - SCHEDULED stamp, inline tags, agenda dates
+* **Other Elements** - SCHEDULED stamp, inline tags, agenda dates, property drawers
 
 #### 💾 Save & Reset <a id="save-and-reset"></a>
 

--- a/org-vscode/out/syntaxColorCustomizer.js
+++ b/org-vscode/out/syntaxColorCustomizer.js
@@ -155,6 +155,12 @@ const DEFAULT_COLORS = {
     background: "",
     fontStyle: ""
   },
+  "Property Drawer": {
+    scope: "meta.block.property.vso",
+    foreground: "#cccccc",
+    background: "",
+    fontStyle: ""
+  },
   "Property Key": {
     scope: "variable.other.property-key.vso",
     foreground: "#b5cea8",
@@ -318,6 +324,7 @@ const SCOPE_GROUPS = {
     "Heading Level 2",
     "Heading Level 3",
     "Org Directive",
+    "Property Drawer",
     "Property Key"
   ],
   "Org Syntax": [
@@ -552,7 +559,7 @@ function getWebviewContent(nonce, currentColors) {
     const scopesHtml = scopeNames.map(name => {
       const settings = currentColors[name];
       const technicalScope = Array.isArray(settings.scope) ? settings.scope.join(", ") : settings.scope;
-      const supportsBackground = /\bKeyword\b/.test(name);
+      const supportsBackground = /\bKeyword\b/.test(name) || name === "Property Drawer";
 
       const previewSelector = `.preview[data-scope="${escapeCssAttrValue(name)}"]`;
       const previewRule = [
@@ -1257,6 +1264,7 @@ function getPreviewText(scopeName) {
     "Agenda Date": "[12-11-2025]",
     "Day Header Date": "[12-11-2025 Thu]",
     "Org Directive": "#+TITLE: Work",
+    "Property Drawer": ":PROPERTIES: ... :END:",
     "Property Key": ":OWNER: Doug",
     "Heading Level 1": "* Heading",
     "Heading Level 2": "** Subheading",

--- a/package.json
+++ b/package.json
@@ -228,6 +228,13 @@
 						}
 					},
 					{
+						"name": "Property Drawer",
+						"scope": "meta.block.property.vso",
+						"settings": {
+							"foreground": "#cccccc"
+						}
+					},
+					{
 						"name": "Property Key",
 						"scope": "variable.other.property-key.vso",
 						"settings": {


### PR DESCRIPTION
Adds a dedicated Syntax Color Customizer entry for property drawers (TextMate scope meta.block.property.vso), plus docs + Unreleased changelog note.

- Customizer: new Property Drawer control (supports background in UI)
- Defaults: adds Property Drawer rule to configurationDefaults
- Docs: README + howto + changelog (Unreleased)

No version bump (queued for 2.2.5 with other upcoming features).