### PR TITLE
Fix Move Block Up/Down to keep children

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Most editing shortcuts support multi-line selection: highlight multiple task lin
 | -------------------- | ------------------------------------------------------ |
 | `Ctrl + →`           | Cycle TODO keyword forward (selection-aware)           |
 | `Ctrl + ←`           | Cycle TODO keyword backward (selection-aware)          |
-| `Shift + Alt + ↑`    | Move task block up                                     |
-| `Shift + Alt + ↓`    | Move task block down                                   |
+| `Shift + Alt + ↑`    | Move task block up (keeps children/subtree)            |
+| `Shift + Alt + ↓`    | Move task block down (keeps children/subtree)          |
 | `Alt + →`            | Increase heading level (selection-aware)               |
 | `Alt + ←`            | Decrease heading level (selection-aware)               |
 | `Alt + Enter`        | Smart insert new element (Org Meta-Return style)       |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **Syntax Color Customizer:** Added a `Property Drawer` control (scope: `meta.block.property.vso`) so you can style `:PROPERTIES:`…`:END:` blocks.
 
+`Fixed / Enhanced`
+
+- **Move Block Up/Down:** Moving a task block now keeps its full subtree together (child headings, drawers, and indented content) and works when your cursor is anywhere inside the block.
+
 # [2.2.4] 01-11-26
 
 `Added / Enhanced`

--- a/examples/demo-walkthrough.org
+++ b/examples/demo-walkthrough.org
@@ -26,6 +26,7 @@
 * TODO Multi-line status change #3 :MULTILINE:
 
 # 3) Move blocks up/down (Shift+Alt+Up/Down)
+# Works from anywhere inside the task block and keeps child tasks/drawers/checklists together.
 * TODO Move this task block around :EDITING:
   Some indented notes move with the task.
   - [ ] And checkboxes move too

--- a/org-vscode/test/unit/move-block.test.js
+++ b/org-vscode/test/unit/move-block.test.js
@@ -1,0 +1,84 @@
+const assert = require('assert');
+const path = require('path');
+
+const { computeMoveBlockResult } = require(path.join(__dirname, '..', '..', 'out', 'moveBlockUtils.js'));
+
+function testMoveDownMovesWholeSubtreeFromInsideDrawer() {
+  const lines = [
+    '* [2026-01-12 Mon] ------------------------------------------------',
+    '  * TODO This is the first task [/]  :SDN:TRAINING:JUICY:',
+    '    SCHEDULED: [2026-01-12]  DEADLINE: [2026-01-12]',
+    '    :PROPERTIES:',
+    '    :CATEGORY: EXAMPLE',
+    '    :END:',
+    '    - [ ] fart',
+    '  ** TODO This is a subtask of the [/]',
+    '    SCHEDULED: [2026-01-12]  DEADLINE: [2026-01-17]',
+    '    - [ ] Checkbox 1',
+    '  * TODO This is a second task :JUICY:',
+    '    SCHEDULED: [2026-01-12]  DEADLINE: [2026-01-17]'
+  ];
+
+  // Cursor inside the property drawer of the first task.
+  const cursorLine = 4;
+  const result = computeMoveBlockResult(lines, cursorLine, 'down');
+  assert.ok(result, 'Expected a move result');
+
+  const updated = result.updatedLines;
+  assert.strictEqual(updated[0], lines[0]);
+  assert.strictEqual(updated[1], lines[10]);
+  assert.strictEqual(updated[2], lines[11]);
+
+  // First task should now appear after the second task, including its child subtree.
+  assert.strictEqual(updated[3], lines[1]);
+  assert.strictEqual(updated[4], lines[2]);
+  assert.strictEqual(updated[5], lines[3]);
+  assert.strictEqual(updated[6], lines[4]);
+  assert.strictEqual(updated[7], lines[5]);
+  assert.strictEqual(updated[8], lines[6]);
+  assert.strictEqual(updated[9], lines[7]);
+  assert.strictEqual(updated[10], lines[8]);
+  assert.strictEqual(updated[11], lines[9]);
+}
+
+function testMoveUpMovesWholeSubtreeFromInsideBody() {
+  const lines = [
+    '* [2026-01-12 Mon] ------------------------------------------------',
+    '  * TODO A :JUICY:',
+    '    SCHEDULED: [2026-01-12]  DEADLINE: [2026-01-17]',
+    '  * TODO B :JUICY:',
+    '    SCHEDULED: [2026-01-12]  DEADLINE: [2026-01-12]',
+    '    :PROPERTIES:',
+    '    :CATEGORY: EXAMPLE',
+    '    :END:',
+    '  ** TODO B child',
+    '    - [ ] c1'
+  ];
+
+  // Cursor inside the body of B.
+  const cursorLine = 6;
+  const result = computeMoveBlockResult(lines, cursorLine, 'up');
+  assert.ok(result, 'Expected a move result');
+
+  const updated = result.updatedLines;
+  assert.strictEqual(updated[0], lines[0]);
+
+  // B (with child) should now be before A.
+  assert.strictEqual(updated[1], lines[3]);
+  assert.strictEqual(updated[2], lines[4]);
+  assert.strictEqual(updated[3], lines[5]);
+  assert.strictEqual(updated[4], lines[6]);
+  assert.strictEqual(updated[5], lines[7]);
+  assert.strictEqual(updated[6], lines[8]);
+  assert.strictEqual(updated[7], lines[9]);
+  assert.strictEqual(updated[8], lines[1]);
+  assert.strictEqual(updated[9], lines[2]);
+}
+
+module.exports = {
+  name: 'unit/move-block',
+  run: () => {
+    testMoveDownMovesWholeSubtreeFromInsideDrawer();
+    testMoveUpMovesWholeSubtreeFromInsideBody();
+  }
+};

--- a/org-vscode/test/unit/run.js
+++ b/org-vscode/test/unit/run.js
@@ -11,6 +11,7 @@ const tests = [
   require(path.join(__dirname, 'checkbox-cookie-toggle.test.js')),
   require(path.join(__dirname, 'checkbox-auto-done.test.js')),
   require(path.join(__dirname, 'checkbox-toggle.test.js')),
+  require(path.join(__dirname, 'move-block.test.js')),
   require(path.join(__dirname, 'org-properties.test.js')),
   require(path.join(__dirname, 'smart-insert-new-element.test.js')),
   require(path.join(__dirname, 'math-decorations-map.test.js')),


### PR DESCRIPTION
Fixes Move Block Up/Down so it moves the whole subtree (child headings, property drawers, and indented content) and works when your cursor is anywhere inside the block.

- Adds pure helper: org-vscode/out/moveBlockUtils.js
- Updates commands: org-vscode/out/moveUp.js and org-vscode/out/moveDown.js
- Adds unit coverage: org-vscode/test/unit/move-block.test.js
- Docs: README + demo-walkthrough + docs/CHANGELOG.md (Unreleased)

No version bump.