### PR TITLE
Issue #76: Auto-indent body/planning lines

### DIFF
--- a/org-vscode/out/agenda/agenda.js
+++ b/org-vscode/out/agenda/agenda.js
@@ -10,6 +10,7 @@ const path = require("path");
 const { stripAllTagSyntax, getPlanningForHeading, isPlanningLine, parsePlanningFromText, normalizeTagsAfterPlanning, getAcceptedDateFormats, DEADLINE_REGEX, stripInlinePlanning } = require("../orgTagUtils");
 const { formatCheckboxStats, findCheckboxCookie, computeHierarchicalCheckboxStatsInRange } = require("../checkboxStats");
 const { computeCheckboxToggleEdits } = require("../checkboxToggle");
+const { normalizeBodyIndentation } = require("../indentUtils");
 
 function escapeRegExp(text) {
   return String(text).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -448,6 +449,8 @@ module.exports = function () {
             const starPrefixMatch = currentLine.text.match(/^\s*(\*+)/);
             const starPrefix = starPrefixMatch ? starPrefixMatch[1] : "*";
 
+            const bodyIndent = normalizeBodyIndentation(config.get("bodyIndentation", 2), 2);
+
             const indent = currentLine.text.match(/^\s*/)?.[0] || "";
 
             const cleanedHeadline = taskKeywordManager.cleanTaskText(
@@ -455,7 +458,7 @@ module.exports = function () {
             );
             const newHeadlineOnly = taskKeywordManager.buildTaskLine(indent, newStatus, cleanedHeadline, { headingMarkerStyle, starPrefix });
 
-            const planningIndent = `${indent}  `;
+            const planningIndent = `${indent}${bodyIndent}`;
             const planningFromHead = parsePlanningFromText(currentLine.text);
             const planningFromNext = (nextLine && isPlanningLine(nextLine.text)) ? parsePlanningFromText(nextLine.text) : {};
             const planningFromNextNext = (nextNextLine && isPlanningLine(nextNextLine.text)) ? parsePlanningFromText(nextNextLine.text) : {};

--- a/org-vscode/out/calendar.js
+++ b/org-vscode/out/calendar.js
@@ -6,6 +6,7 @@ const path = require("path");       // For cross-platform path handling
 const moment = require("moment");   // Date formatting library
 const taskKeywordManager = require("./taskKeywordManager");
 const { getAllTagsFromLine, stripAllTagSyntax, parseFileTagsFromText, createInheritanceTracker, getPlanningForHeading, isPlanningLine, normalizeTagsAfterPlanning, getAcceptedDateFormats, buildScheduledReplacement, getMatchingScheduledOnLine, SCHEDULED_STRIP_RE, SCHEDULED_REGEX, DEADLINE_REGEX } = require("./orgTagUtils");
+const { normalizeBodyIndentation } = require("./indentUtils");
 
 function escapeRegExp(text) {
   return String(text).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -64,6 +65,7 @@ function sendTasksToCalendar(panel) {
   let dirPath = setMainDir();
   const config = vscode.workspace.getConfiguration("Org-vscode");
   const dateFormat = config.get("dateFormat", "YYYY-MM-DD");
+  const bodyIndent = normalizeBodyIndentation(config.get("bodyIndentation", 2), 2);
   const registry = taskKeywordManager.getWorkflowRegistry();
   const headingStartRegex = buildHeadingStartRegex(registry);
 
@@ -285,7 +287,7 @@ function rescheduleTaskById(taskId, newDate) {
   lines[lineIndex] = headlineText;
 
   const headlineIndent = headlineText.match(/^\s*/)?.[0] || "";
-  const planningIndent = `${headlineIndent}  `;
+  const planningIndent = `${headlineIndent}${bodyIndent}`;
   const scheduledTag = `SCHEDULED: [${formattedNewDate}]`;
 
   const nextLine = (lineIndex + 1 < lines.length) ? lines[lineIndex + 1] : "";

--- a/org-vscode/out/checkboxAutoDone.js
+++ b/org-vscode/out/checkboxAutoDone.js
@@ -7,6 +7,7 @@ const taskKeywordManager = require("./taskKeywordManager");
 const continuedTaskHandler = require("./continuedTaskHandler");
 const { isPlanningLine, parsePlanningFromText, normalizeTagsAfterPlanning, stripInlinePlanning } = require("./orgTagUtils");
 const { computeHeadingTransitions } = require("./checkboxAutoDoneTransitions");
+const { normalizeBodyIndentation } = require("./indentUtils");
 
 const CHECKBOX_REGEX = /^\s*[-+*]\s+\[( |x|X)\]\s+/;
 
@@ -51,6 +52,7 @@ async function applyDoneToHeading(document, lineNumber) {
   const config = vscode.workspace.getConfiguration("Org-vscode");
   const headingMarkerStyle = config.get("headingMarkerStyle", "unicode");
   const dateFormat = config.get("dateFormat", "YYYY-MM-DD");
+  const bodyIndent = normalizeBodyIndentation(config.get("bodyIndentation", 2), 2);
   const registry = taskKeywordManager.getWorkflowRegistry();
 
   const currentLine = document.lineAt(lineNumber);
@@ -101,7 +103,7 @@ async function applyDoneToHeading(document, lineNumber) {
   const newLine = taskKeywordManager.buildTaskLine(leadingSpaces, nextKeyword, cleanedText, { headingMarkerStyle, starPrefix });
   workspaceEdit.replace(document.uri, currentLine.range, newLine);
 
-  const planningIndent = `${leadingSpaces}  `;
+  const planningIndent = `${leadingSpaces}${bodyIndent}`;
   const planningBody = buildPlanningBody(mergedPlanning);
 
   if (planningBody) {
@@ -124,6 +126,7 @@ async function applyDoneToHeading(document, lineNumber) {
 async function applyInProgressToHeading(document, lineNumber) {
   const config = vscode.workspace.getConfiguration("Org-vscode");
   const headingMarkerStyle = config.get("headingMarkerStyle", "unicode");
+  const bodyIndent = normalizeBodyIndentation(config.get("bodyIndentation", 2), 2);
   const registry = taskKeywordManager.getWorkflowRegistry();
 
   const currentLine = document.lineAt(lineNumber);
@@ -166,7 +169,7 @@ async function applyInProgressToHeading(document, lineNumber) {
   const newLine = taskKeywordManager.buildTaskLine(leadingSpaces, nextKeyword, cleanedText, { headingMarkerStyle, starPrefix });
   workspaceEdit.replace(document.uri, currentLine.range, newLine);
 
-  const planningIndent = `${leadingSpaces}  `;
+  const planningIndent = `${leadingSpaces}${bodyIndent}`;
   const planningBody = buildPlanningBody(mergedPlanning);
 
   if (planningBody) {

--- a/org-vscode/out/continuedTaskHandler.js
+++ b/org-vscode/out/continuedTaskHandler.js
@@ -2,6 +2,7 @@
 const vscode = require("vscode");
 const moment = require("moment");
 const taskKeywordManager = require("./taskKeywordManager");
+const { normalizeBodyIndentation } = require("./indentUtils");
 const {
   isPlanningLine,
   parsePlanningFromText,
@@ -150,6 +151,7 @@ function buildForwardedTask(originalLine, newDate, indent = "  ") {
 
   const config = vscode.workspace.getConfiguration("Org-vscode");
   const headingMarkerStyle = config.get("headingMarkerStyle", "unicode");
+  const bodyIndent = normalizeBodyIndentation(config.get("bodyIndentation", 2), 2);
   const starPrefixMatch = originalLine.match(/^\s*(\*+)/);
   const starPrefix = starPrefixMatch ? starPrefixMatch[1] : "*";
 
@@ -170,7 +172,7 @@ function buildForwardedTask(originalLine, newDate, indent = "  ") {
     ...planningFromHeadline,
     scheduled: newDate
   };
-  const planningIndent = `${indent}  `;
+  const planningIndent = `${indent}${bodyIndent}`;
   const body = buildPlanningBody(updatedPlanning);
   return body ? `${headline}\n${planningIndent}${body}` : headline;
 }

--- a/org-vscode/out/deadline.js
+++ b/org-vscode/out/deadline.js
@@ -4,6 +4,7 @@ const vscode = require("vscode");
 const moment = require("moment");
 const showMessage_1 = require("./showMessage");
 const { isPlanningLine, normalizeTagsAfterPlanning, DAY_HEADING_REGEX, getTaskPrefixRegex, DEADLINE_STRIP_RE, SCHEDULED_REGEX } = require("./orgTagUtils");
+const { normalizeBodyIndentation } = require("./indentUtils");
 
 module.exports = function () {
     const { activeTextEditor } = vscode.window;
@@ -17,6 +18,7 @@ module.exports = function () {
 
     const config = vscode.workspace.getConfiguration("Org-vscode");
     const dateFormat = config.get("dateFormat", "YYYY-MM-DD");
+    const bodyIndent = normalizeBodyIndentation(config.get("bodyIndentation", 2), 2);
 
     const selections = (activeTextEditor.selections && activeTextEditor.selections.length)
         ? activeTextEditor.selections
@@ -154,7 +156,7 @@ module.exports = function () {
                 workspaceEdit.replace(document.uri, currentLine.range, headlineText);
 
                 const headlineIndent = headlineText.match(/^\s*/)?.[0] || "";
-                const planningIndent = `${headlineIndent}  `;
+                const planningIndent = `${headlineIndent}${bodyIndent}`;
                 const deadlineTag = `DEADLINE: [${formattedDate}]`;
 
                 const hasNext = (lineNumber + 1 < document.lineCount);

--- a/org-vscode/out/indentUtils.js
+++ b/org-vscode/out/indentUtils.js
@@ -1,0 +1,53 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.computeDesiredIndentForNewLine = computeDesiredIndentForNewLine;
+exports.normalizeBodyIndentation = normalizeBodyIndentation;
+
+function leadingWhitespace(text) {
+  const match = String(text || "").match(/^\s*/);
+  return match ? match[0] : "";
+}
+
+function isHeadingLine(text) {
+  const line = String(text || "");
+  // Asterisk-mode headings: "* ", "** ", etc.
+  if (/^\s*\*+\s+/.test(line)) return true;
+  // Unicode-mode headings: "⊙ ", "⊘ ", etc.
+  if (/^\s*[⊙⊘⊖⊜⊗]\s/.test(line)) return true;
+  return false;
+}
+
+function normalizeBodyIndentation(raw, defaultCount = 2) {
+  const fallback = Math.max(0, Math.floor(Number(defaultCount) || 0));
+  const count = Math.max(0, Math.floor(Number(raw) || 0));
+  // If caller passes undefined/null/NaN, honor fallback.
+  const finalCount = (raw === undefined || raw === null || Number.isNaN(Number(raw))) ? fallback : count;
+  return " ".repeat(finalCount);
+}
+
+/**
+ * Computes the desired indentation for a newly created line.
+ *
+ * Behavior:
+ * - If the nearest previous non-empty line is a heading, indent to heading indent + 2 spaces.
+ * - Otherwise, keep the indentation of that nearest previous non-empty line.
+ *
+ * @param {(lineIndex: number) => string} getLineText
+ * @param {number} lineIndex The current line index (0-based) where indent is being computed.
+ * @param {{ bodyIndent?: string }} [options]
+ * @returns {string}
+ */
+function computeDesiredIndentForNewLine(getLineText, lineIndex, options) {
+  const bodyIndent = (options && typeof options.bodyIndent === "string") ? options.bodyIndent : "  ";
+
+  for (let i = lineIndex - 1; i >= 0; i--) {
+    const text = String(getLineText(i) || "");
+    if (!text.trim()) continue;
+
+    const baseIndent = leadingWhitespace(text);
+    if (isHeadingLine(text)) return baseIndent + bodyIndent;
+    return baseIndent;
+  }
+
+  return "";
+}

--- a/org-vscode/out/keywordLeft.js
+++ b/org-vscode/out/keywordLeft.js
@@ -5,6 +5,7 @@ const taskKeywordManager = require("./taskKeywordManager");
 const continuedTaskHandler = require("./continuedTaskHandler");
 const moment = require("moment");
 const { isPlanningLine, parsePlanningFromText, normalizeTagsAfterPlanning, stripInlinePlanning } = require("./orgTagUtils");
+const { normalizeBodyIndentation } = require("./indentUtils");
 
 function buildPlanningBody(planning) {
   const parts = [];
@@ -23,6 +24,7 @@ module.exports = async function () {
   const config = vscode.workspace.getConfiguration("Org-vscode");
   const headingMarkerStyle = config.get("headingMarkerStyle", "unicode");
   const dateFormat = config.get("dateFormat", "YYYY-MM-DD");
+  const bodyIndent = normalizeBodyIndentation(config.get("bodyIndentation", 2), 2);
   const workflowRegistry = taskKeywordManager.getWorkflowRegistry();
 
   const { document } = activeTextEditor;
@@ -103,7 +105,7 @@ module.exports = async function () {
       mergedPlanning.closed = null;
     }
 
-    const planningIndent = `${leadingSpaces}  `;
+    const planningIndent = `${leadingSpaces}${bodyIndent}`;
     const planningBody = buildPlanningBody(mergedPlanning);
 
     // Handle forward-trigger transitions (default: CONTINUED)
@@ -197,7 +199,7 @@ module.exports = async function () {
         const hasClosed = Boolean(originalLines[i + 1]?.includes("CLOSED") || originalLines[i + 1]?.includes("COMPLETED"));
         if (change.stampsClosed) {
           if (!hasClosed) {
-            originalLines.splice(i + 1, 0, taskKeywordManager.buildCompletedStamp(origIndent, dateFormat));
+            originalLines.splice(i + 1, 0, taskKeywordManager.buildCompletedStamp(origIndent, dateFormat, bodyIndent));
           }
         } else if (hasClosed) {
           originalLines.splice(i + 1, 1);

--- a/org-vscode/out/scheduling.js
+++ b/org-vscode/out/scheduling.js
@@ -4,6 +4,7 @@ const vscode = require("vscode");
 const showMessage_1 = require("./showMessage");
 const moment = require("moment");
 const { isPlanningLine, normalizeTagsAfterPlanning, DAY_HEADING_REGEX, getTaskPrefixRegex, SCHEDULED_STRIP_RE, DEADLINE_REGEX } = require("./orgTagUtils");
+const { normalizeBodyIndentation } = require("./indentUtils");
 module.exports = function () {
     const { activeTextEditor } = vscode.window;
     if (!activeTextEditor || activeTextEditor.document.languageId !== "vso") {
@@ -41,6 +42,7 @@ module.exports = function () {
     let workspaceEdit = new vscode.WorkspaceEdit();
     const config = vscode.workspace.getConfiguration("Org-vscode");
     const dateFormat = config.get("dateFormat", "YYYY-MM-DD");
+    const bodyIndent = normalizeBodyIndentation(config.get("bodyIndentation", 2), 2);
     // Messages
     const fullDateMessage = new showMessage_1.WindowMessage("warning", "Full date must be entered", false, false);
     const notADateMessage = new showMessage_1.WindowMessage("warning", "That's not a valid date.", false, false);
@@ -152,7 +154,7 @@ module.exports = function () {
                 workspaceEdit.replace(document.uri, currentLine.range, headlineText);
 
                 const headlineIndent = headlineText.match(/^\s*/)?.[0] || "";
-                const planningIndent = `${headlineIndent}  `;
+                const planningIndent = `${headlineIndent}${bodyIndent}`;
 
                 const hasNext = (lineNumber + 1 < document.lineCount);
                 const nextLine = hasNext ? document.lineAt(lineNumber + 1) : null;

--- a/org-vscode/out/setTodoState.js
+++ b/org-vscode/out/setTodoState.js
@@ -5,6 +5,7 @@ const taskKeywordManager = require("./taskKeywordManager");
 const continuedTaskHandler = require("./continuedTaskHandler");
 const moment = require("moment");
 const { isPlanningLine, parsePlanningFromText, normalizeTagsAfterPlanning, stripInlinePlanning } = require("./orgTagUtils");
+const { normalizeBodyIndentation } = require("./indentUtils");
 
 function buildPlanningBody(planning) {
   const parts = [];
@@ -23,6 +24,7 @@ module.exports = async function () {
   const config = vscode.workspace.getConfiguration("Org-vscode");
   const headingMarkerStyle = config.get("headingMarkerStyle", "unicode");
   const dateFormat = config.get("dateFormat", "YYYY-MM-DD");
+  const bodyIndent = normalizeBodyIndentation(config.get("bodyIndentation", 2), 2);
   const workflowRegistry = taskKeywordManager.getWorkflowRegistry();
 
   const cycleKeywords = workflowRegistry.getCycleKeywords();
@@ -142,7 +144,7 @@ module.exports = async function () {
     const newLine = taskKeywordManager.buildTaskLine(leadingSpaces, targetKeyword, cleanedText, { headingMarkerStyle, starPrefix });
     workspaceEdit.replace(document.uri, currentLine.range, newLine);
 
-    const planningIndent = `${leadingSpaces}  `;
+    const planningIndent = `${leadingSpaces}${bodyIndent}`;
     const planningBody = buildPlanningBody(mergedPlanning);
 
     // Normalize planning line placement immediately after the headline.
@@ -222,7 +224,7 @@ module.exports = async function () {
         const hasClosed = Boolean(originalLines[i + 1]?.includes("CLOSED") || originalLines[i + 1]?.includes("COMPLETED"));
         if (change.stampsClosed) {
           if (!hasClosed) {
-            originalLines.splice(i + 1, 0, taskKeywordManager.buildCompletedStamp(origIndent, dateFormat));
+            originalLines.splice(i + 1, 0, taskKeywordManager.buildCompletedStamp(origIndent, dateFormat, bodyIndent));
           }
         } else if (hasClosed) {
           originalLines.splice(i + 1, 1);

--- a/org-vscode/out/taggedAgenda.js
+++ b/org-vscode/out/taggedAgenda.js
@@ -5,6 +5,7 @@ const os = require("os");
 const moment = require("moment");
 const taskKeywordManager = require("./taskKeywordManager");
 const continuedTaskHandler = require("./continuedTaskHandler");
+const { normalizeBodyIndentation } = require("./indentUtils");
 const { stripAllTagSyntax, parseFileTagsFromText, parseTagGroupsFromText, createInheritanceTracker, matchesTagMatchString, normalizeTagMatchInput, getPlanningForHeading, isPlanningLine, parsePlanningFromText, normalizeTagsAfterPlanning, getAcceptedDateFormats, stripInlinePlanning } = require("./orgTagUtils");
 const { computeCheckboxStatsByHeadingLine, formatCheckboxStats, findCheckboxCookie } = require("./checkboxStats");
 const { computeCheckboxToggleEdits } = require("./checkboxToggle");
@@ -38,6 +39,7 @@ function getKeywordBucket(keyword, registry) {
 
 module.exports = async function taggedAgenda() {
   const config = vscode.workspace.getConfiguration("Org-vscode");
+  const bodyIndent = normalizeBodyIndentation(config.get("bodyIndentation", 2), 2);
   const includeContinuedInTaggedAgenda = config.get("includeContinuedInTaggedAgenda", false);
   const registry = taskKeywordManager.getWorkflowRegistry();
   const headingStartRegex = buildHeadingStartRegex(registry);
@@ -204,7 +206,7 @@ async function updateTaskStatusInFile(file, taskText, scheduledDate, newStatus, 
   );
   let newLine = taskKeywordManager.buildTaskLine(indent, newStatus, cleanedHeadline, { headingMarkerStyle, starPrefix });
 
-  const planningIndent = `${indent}  `;
+  const planningIndent = `${indent}${bodyIndent}`;
   const planningLines = document.getText().split(/\r?\n/);
   const planningFromHead = parsePlanningFromText(currentLine.text);
   const planningFromNext = (nextLine && isPlanningLine(nextLine.text)) ? parsePlanningFromText(nextLine.text) : {};

--- a/org-vscode/out/taskKeywordManager.js
+++ b/org-vscode/out/taskKeywordManager.js
@@ -133,9 +133,10 @@ function buildTaskLine(leadingSpaces, keyword, cleanedText, options = {}) {
   return `${leadingSpaces}${marker}${keyword}${suffix}`;
 }
 
-function buildCompletedStamp(leadingSpaces, dateFormat) {
+function buildCompletedStamp(leadingSpaces, dateFormat, bodyIndent) {
   const fmt = dateFormat || "MM-DD-YYYY";
-  return `${leadingSpaces}  CLOSED:[${moment().format(`${fmt} ddd HH:mm`)}]`;
+  const indent = (typeof bodyIndent === "string") ? bodyIndent : "  ";
+  return `${leadingSpaces}${indent}CLOSED:[${moment().format(`${fmt} ddd HH:mm`)}]`;
 }
 
 // Back-compat alias: prefer CLOSED, but keep the existing exported name.

--- a/org-vscode/test/unit/indent-utils.test.js
+++ b/org-vscode/test/unit/indent-utils.test.js
@@ -1,0 +1,44 @@
+const assert = require('assert');
+
+const { computeDesiredIndentForNewLine } = require('../../out/indentUtils');
+
+module.exports = {
+  name: 'indent-utils',
+  run() {
+    {
+      const lines = ['* TODO Heading'];
+      const indent = computeDesiredIndentForNewLine((i) => lines[i], 1);
+      assert.strictEqual(indent, '  ', 'Indents body line after asterisk heading');
+    }
+
+    {
+      const lines = ['* TODO Heading'];
+      const indent = computeDesiredIndentForNewLine((i) => lines[i], 1, { bodyIndent: '    ' });
+      assert.strictEqual(indent, '    ', 'Honors configured bodyIndent when under heading');
+    }
+
+    {
+      const lines = ['  ⊙ TODO Heading'];
+      const indent = computeDesiredIndentForNewLine((i) => lines[i], 1);
+      assert.strictEqual(indent, '    ', 'Indents body line after unicode heading (preserves heading indent + 2)');
+    }
+
+    {
+      const lines = ['* TODO Heading', '  some body'];
+      const indent = computeDesiredIndentForNewLine((i) => lines[i], 2);
+      assert.strictEqual(indent, '  ', 'Keeps indent of previous body line');
+    }
+
+    {
+      const lines = ['* TODO Heading', '', ''];
+      const indent = computeDesiredIndentForNewLine((i) => lines[i], 3);
+      assert.strictEqual(indent, '  ', 'Skips blank lines and uses nearest previous non-empty');
+    }
+
+    {
+      const lines = ['plain text'];
+      const indent = computeDesiredIndentForNewLine((i) => lines[i], 1);
+      assert.strictEqual(indent, '', 'No indentation added when not under heading');
+    }
+  }
+};

--- a/org-vscode/test/unit/run.js
+++ b/org-vscode/test/unit/run.js
@@ -8,6 +8,7 @@ const path = require('path');
 const tests = [
   require(path.join(__dirname, 'command-registration.test.js')),
   require(path.join(__dirname, 'workflow-states.test.js')),
+  require(path.join(__dirname, 'indent-utils.test.js')),
   require(path.join(__dirname, 'checkbox-stats.test.js')),
   require(path.join(__dirname, 'checkbox-cookie-toggle.test.js')),
   require(path.join(__dirname, 'checkbox-auto-done.test.js')),


### PR DESCRIPTION
﻿Implements Issue #76 (auto-indent of non-header text) and makes alignSchedules configurable (tags-only supported; no more :PROPERTIES: drawer alignment).

Key settings:
- Org-vscode.autoIndentNonHeaderText
- Org-vscode.bodyIndentation
- Org-vscode.alignSchedulesAlignTags
- Org-vscode.alignSchedulesAlignInlineScheduled
- Org-vscode.alignSchedulesNormalizePlanningLines

Tests: node org-vscode/test/unit/run.js
