### PR TITLE
calendar: On click, open the org file in the other pane.

### DIFF
--- a/org-vscode/out/calendar.js
+++ b/org-vscode/out/calendar.js
@@ -357,7 +357,7 @@ function openCalendarView() {
       // Open a specific org file in the editor
       let filePath = path.join(setMainDir(), message.file);
       vscode.workspace.openTextDocument(vscode.Uri.file(filePath)).then(doc => {
-        vscode.window.showTextDocument(doc);
+        vscode.window.showTextDocument(doc, vscode.ViewColumn.One, false);
       });
 
     } else if (message.command === "rescheduleTask") {


### PR DESCRIPTION
Before:
- agenda opens the org file in the other pane, leaving the agenda open.
- calendar opens the org file in the calendar pane, closing the calendar.

This change makes calendar open the org file in the other pane, leaving the calendar open.