### PR TITLE
Release 2.2.10: planning + repeaters + checkbox multi-select

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Most editing shortcuts support multi-line selection: highlight multiple task lin
 | `Ctrl + Shift + ]`   | Unfold section                                         |
 | `Ctrl + Alt + S`     | Schedule a task (selection-aware)                      |
 | `Ctrl + Alt + D`     | Add deadline to task (selection-aware)                 |
-| `Ctrl + Alt + X`     | Toggle checkbox item on current line                   |
+| `Ctrl + Alt + X`     | Toggle checkbox item (selection-aware)                 |
 | `Alt + Shift + →`    | Smart date forward (selection-aware)                   |
 | `Alt + Shift + ←`    | Smart date backward (selection-aware)                  |
 | `Ctrl + Shift + →`   | Deadline date forward (selection-aware)                |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,21 @@
 - (none)
 
 
+# [2.2.10] 01-17-26
+
+`Fixed / Enhanced`
+
+- **Agenda View deadline parsing:** Fixed "Due: Invalid date" badges caused by legacy planning stamp parsing.
+- **Checkbox auto-DONE:** Fixed auto-done not closing tasks and improved correctness:
+  - A parent task no longer auto-completes if any child subtask heading is still TODO.
+  - Repeating tasks now complete+log, then reschedule/reopen and reset their subtree (checkboxes unchecked + child subtasks reset) for the next iteration.
+- **Checkbox toggle (multi-line):** `Ctrl+Alt+X` now supports multi-line selections and can bulk-check or bulk-uncheck.
+- **Move Block Up/Down (multi-line):** Range selections can move multiple sibling subtrees together.
+- **Set Repeater:** Fixed repeater command output that could produce malformed planning like `SCHEDULED: [< ...]`.
+- **Migration:** `Migrate File to v2` now converts legacy `SCHEDULED/DEADLINE: [...]` planning stamps to active `<...>` (and repairs malformed `[< ...]`).
+- **Tagged Agenda:** Added AgendaView-style deadline badges/icons for faster scanning.
+
+
 # [2.2.9] 01-16-26
 
 `Added / Enhanced`

--- a/docs/howto.md
+++ b/docs/howto.md
@@ -253,7 +253,7 @@ Just type the prefix and hit `Tab` to expand the snippet inside a `.org` file.
 
 ```org
 * TODO Task description
-  SCHEDULED: [04-21-2025]
+  SCHEDULED: <04-21-2025>
 ```
 
 ---
@@ -381,7 +381,7 @@ IDs are used for cross-file link navigation and completion via `[[id:...]]`.
 
 ```org
 * TODO Task Name
-  SCHEDULED: [04-21-2025]
+  SCHEDULED: <04-21-2025>
   CLOSED: []
 
 - Description:
@@ -490,6 +490,19 @@ Place the cursor anywhere on a checkbox line (you do not need to put the cursor 
 
 This toggles the current checkbox and updates parent/child `[-]` / `[X]` / `[ ]` states.
 
+Multi-line selection support:
+
+- If you select multiple checkbox lines and press `Ctrl + Alt + X`, Org-vscode bulk-toggles the selection:
+  - if **all** selected checkbox items are checked, it **unchecks** them all
+  - otherwise it **checks** them all
+
+Auto-DONE behavior:
+
+- If `Org-vscode.autoDoneWhenAllCheckboxesChecked` is enabled, a task only auto-completes when:
+  - all checkboxes in its subtree are checked, and
+  - there are no incomplete child task headings (e.g. `** TODO ...`) in that subtree
+- For repeating tasks, completing the last checkbox will reschedule/reopen the task and reset the subtree (checkboxes unchecked, child subtasks reset) for the next iteration.
+
 ### Toggle checkboxes from Agenda / Tagged Agenda
 
 In both Agenda View and Tagged Agenda View:
@@ -522,7 +535,7 @@ Add deadline dates to tasks to track when they're due. Deadlines appear in the A
 
 ```org
 * TODO Complete documentation :PROJECT:
-  SCHEDULED: [12-10-2025]  DEADLINE: [12-15-2025]
+  SCHEDULED: <12-10-2025>  DEADLINE: <12-15-2025>
 ```
 
 Date formatting is controlled by `Org-vscode.dateFormat` (default: `MM-DD-YYYY`).
@@ -556,7 +569,7 @@ Add a repeater token inside the timestamp:
 
 ```org
 * TODO Pay rent
-  SCHEDULED: [01-01-2026 +1m]
+  SCHEDULED: <01-01-2026 +1m>
 ```
 
 Supported repeater styles:
@@ -583,7 +596,7 @@ To reopen to a specific state, set `REPEAT_TO_STATE` in a property drawer (suppo
   :END:
 
 ** TODO Weekly review
-   SCHEDULED: [01-15-2026 +1w]
+  SCHEDULED: <01-15-2026 +1w>
 ```
 
 ### Command: Set Repeater
@@ -618,16 +631,16 @@ This works both from the editor hotkeys and when you click the keyword in Agenda
 **Before toggling to CONTINUED:**
 ```org
 * [12-10-2025 Wed] -------
-** TODO : Review pull request    SCHEDULED: [12-10-2025]
+** TODO : Review pull request    SCHEDULED: <12-10-2025>
 ```
 
 **After toggling to CONTINUED:**
 ```org
 * [12-10-2025 Wed] -------
-** CONTINUED : Review pull request    SCHEDULED: [12-10-2025]
+** CONTINUED : Review pull request    SCHEDULED: <12-10-2025>
 
 * [12-11-2025 Thu] -------
-** TODO : Review pull request    SCHEDULED: [12-11-2025]
+** TODO : Review pull request    SCHEDULED: <12-11-2025>
 ```
 
 This feature ensures tasks that roll over to the next day are automatically tracked without manual copying.
@@ -722,7 +735,7 @@ Example:
 
 ```org
 * DONE Weekly review
-  SCHEDULED: [2026-01-15 +1w]  CLOSED: [2026-01-16 Fri 09:12]
+  SCHEDULED: <2026-01-15 +1w>  CLOSED: [2026-01-16 Fri 09:12]
   :LOGBOOK:
   - State "DONE" from "TODO" [2026-01-16 Fri 09:12]
   :END:
@@ -790,7 +803,7 @@ In v2 format, planning metadata lives on the indented line directly under the he
 
 ### 🛠 What It Does <a id="what-it-does"></a>
 
-* Scans the file for `SCHEDULED: [<date>]` (format controlled by `Org-vscode.dateFormat`)
+* Scans the file for `SCHEDULED: <date>` (format controlled by `Org-vscode.dateFormat`)
 * Determines the longest task description in the file
 * Pads shorter lines so timestamps and/or end-of-line tags line up cleanly
 * Preserves original indentation
@@ -813,26 +826,26 @@ Optional configuration (tags-only mode):
 
 ```org
 * TODO Review meeting notes :TEST_TAG:
-  SCHEDULED: [06-21-2025] DEADLINE: [06-25-2025]
+  SCHEDULED: <06-21-2025> DEADLINE: <06-25-2025>
 
 * DONE Email client :TEST_TAG:
-  SCHEDULED: [06-20-2025]  DEADLINE: [06-22-2025]
+  SCHEDULED: <06-20-2025>  DEADLINE: <06-22-2025>
 
 * IN_PROGRESS Fix bug :TEST_TAG:
-  SCHEDULED: [06-22-2025] DEADLINE: [06-30-2025]
+  SCHEDULED: <06-22-2025> DEADLINE: <06-30-2025>
 ```
 
 **After Running Align:**
 
 ```org
 * TODO Review meeting notes        :TEST_TAG:
-  SCHEDULED: [06-21-2025]  DEADLINE: [06-25-2025]
+  SCHEDULED: <06-21-2025>  DEADLINE: <06-25-2025>
 
 * DONE Email client                :TEST_TAG:
-  SCHEDULED: [06-20-2025]  DEADLINE: [06-22-2025]
+  SCHEDULED: <06-20-2025>  DEADLINE: <06-22-2025>
 
 * IN_PROGRESS Fix bug              :TEST_TAG:
-  SCHEDULED: [06-22-2025]  DEADLINE: [06-30-2025]
+  SCHEDULED: <06-22-2025>  DEADLINE: <06-30-2025>
 ```
 
 ---
@@ -842,17 +855,17 @@ Optional configuration (tags-only mode):
 **Before:**
 
 ```org
-* TODO Review meeting notes           SCHEDULED: [06-21-2025]
-* DONE Email client      SCHEDULED: [06-20-2025]
-* IN_PROGRESS Fix bug             SCHEDULED: [06-22-2025]
+* TODO Review meeting notes           SCHEDULED: <06-21-2025>
+* DONE Email client      SCHEDULED: <06-20-2025>
+* IN_PROGRESS Fix bug             SCHEDULED: <06-22-2025>
 ```
 
 **After Running Align:**
 
 ```org
-* TODO Review meeting notes           SCHEDULED: [06-21-2025]
-* DONE Email client                   SCHEDULED: [06-20-2025]
-* IN_PROGRESS Fix bug                 SCHEDULED: [06-22-2025]
+* TODO Review meeting notes           SCHEDULED: <06-21-2025>
+* DONE Email client                   SCHEDULED: <06-20-2025>
+* IN_PROGRESS Fix bug                 SCHEDULED: <06-22-2025>
 ```
 
 ---
@@ -950,7 +963,7 @@ Use the command:
 
 #### ✅ Displays Scheduled Tasks <a id="displays-scheduled-tasks"></a>
 
-* Tasks with `SCHEDULED: [<date>]` are shown as calendar events (format controlled by `Org-vscode.dateFormat`).
+* Tasks with `SCHEDULED: <date>` are shown as calendar events (format controlled by `Org-vscode.dateFormat`).
 * Supports both marker styles (`unicode` and `asterisks`).
 * Automatically parses `.org` files in your main directory (excluding `CurrentTasks.org`).
 

--- a/docs/jira-integration.md
+++ b/docs/jira-integration.md
@@ -5,7 +5,8 @@
 If you already use tags like:
 
 ```org
-⊙ TODO Build the new roadmap tool :EPIC:   SCHEDULED: [07-01-2025]
+⊙ TODO Build the new roadmap tool :EPIC:
+   SCHEDULED: <07-01-2025>
 ```
 
 …we can leverage the tag (e.g. `:EPIC:`) to determine what kind of JIRA object to create when a user invokes something like **Create JIRA Task from Org Task**.

--- a/docs/migrate-v1-to-v2.md
+++ b/docs/migrate-v1-to-v2.md
@@ -69,7 +69,7 @@ After (v2 canonical planning line):
 
 ```org
 * TODO Example task :PROJECT:
-  SCHEDULED: [12-29-2025]  DEADLINE: [01-31-2026]
+  SCHEDULED: <12-29-2025>  DEADLINE: <01-31-2026>
 ```
 
 ### Completion stamp

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 ﻿# Roadmap
 
-Live version: 2.2.9
+Live version: 2.2.10
 
 These are the features that I have either already implemented, or plan to in the near future.
 

--- a/examples/demo-walkthrough.org
+++ b/examples/demo-walkthrough.org
@@ -56,18 +56,18 @@
 # 9) Planning lines live under the headline (v2 format)
 # Use Ctrl+Alt+S to toggle SCHEDULED. Use Ctrl+Alt+D to toggle DEADLINE.
 * TODO Schedule + deadline demo :PLANNING:
-  SCHEDULED: [2026-01-07]  DEADLINE: [2026-01-20]
+  SCHEDULED: <2026-01-07>  DEADLINE: <2026-01-20>
 
 # 10) Align Scheduled Tasks (Alt+Shift+A)
 # This is intentionally misaligned spacing; run Align Scheduled Tasks.
 * TODO Misaligned planning line :ALIGN:
-  SCHEDULED: [2026-01-07]   DEADLINE: [2026-01-25]
+  SCHEDULED: <2026-01-07>   DEADLINE: <2026-01-25>
 
 # 11) Date tools
 # - Smart date forward/backward (Alt+Shift+Right/Left)
 # - Deadline date forward/backward (Ctrl+Shift+Right/Left)
 * TODO Try date adjustments here :DATES:
-  SCHEDULED: [2026-01-07]  DEADLINE: [2026-01-21]
+  SCHEDULED: <2026-01-07>  DEADLINE: <2026-01-21>
 
 * [2026-01-08 Thu] Checkboxes + Statistics Cookies ----------------------------------------------
 
@@ -77,6 +77,11 @@
     - [ ] Child 1
     - [ ] Child 2
   - [ ] Standalone item
+
+# Tip: multi-line selection is supported.
+# Select multiple checkbox lines and press Ctrl+Alt+X to bulk-toggle them:
+# - if all selected are checked, they’ll all be unchecked
+# - otherwise they’ll all be checked
 
 # 13) Percent cookie (same stats, different display)
 * TODO Checkbox percent [%] :CHECKBOX:
@@ -98,7 +103,7 @@
 # - checkbox completion under the subtree
 # - TODO subtree completion (DONE/ABANDONED count as complete)
 * TODO Subtree completion overview [/] :SUBTREE:
-  SCHEDULED: [2026-01-09]  DEADLINE: [2026-01-31]
+  SCHEDULED: <2026-01-09>  DEADLINE: <2026-01-31>
 
 ** DONE Child task complete #1
   CLOSED: [2026-01-05 Mon 09:00]
@@ -118,13 +123,13 @@
 # - Tagged Agenda (filter by tags / match strings)
 # - Calendar View
 * TODO Prep demo video outline :WORK:DEMO:
-  SCHEDULED: [2026-01-10]
+  SCHEDULED: <2026-01-10>
 
 * TODO Record the demo :WORK:DEMO:
-  SCHEDULED: [2026-01-10]  DEADLINE: [2026-01-11]
+  SCHEDULED: <2026-01-10>  DEADLINE: <2026-01-11>
 
 * TODO Publish to both marketplaces :RELEASE:DEMO:
-  SCHEDULED: [2026-01-10]
+  SCHEDULED: <2026-01-10>
 
 # 16a) Open Agenda View
 # Command Palette: Org-vscode: Agenda View
@@ -148,13 +153,13 @@
 # - Click a task to reveal it in the source file.
 
 * TODO Calendar drag-drop demo :@WORK:WORK:
-  SCHEDULED: [2026-01-10]
+  SCHEDULED: <2026-01-10>
 
 * TODO Tagged Agenda group demo (matches +GTD) :@HOME:HOME:
-  SCHEDULED: [2026-01-10]
+  SCHEDULED: <2026-01-10>
 
 * CONTINUED Optional includeContinued demo :WORK:
-  SCHEDULED: [2026-01-10]
+  SCHEDULED: <2026-01-10>
   # By default, Tagged Agenda omits CONTINUED tasks to avoid duplicates.
   # To include them, set: Org-vscode.includeContinuedInTaggedAgenda = true
 
@@ -317,3 +322,44 @@
 # Command Palette:
 # - Org-vscode: Open Syntax Color Customizer
 # - Org-vscode: Open Keybinding Customizer
+
+
+* [2026-01-14 Wed] Timestamps (Active vs Inactive) ----------------------------------------------
+
+# 29) Timestamp formats
+# Org uses two timestamp bracket styles:
+# - Active:   <...> (appears in Agenda/Calendar scans)
+# - Inactive: [...] (reference only, used for CLOSED and history)
+#
+# This extension supports the full Emacs timestamp shape, including time ranges,
+# repeaters (+1w, ++1m, .+1d) and warning offsets (-2d).
+
+* TODO Timestamp parsing demo :TIMESTAMPS:
+  SCHEDULED: <2026-01-20 Tue 10:00-11:00 +1w -2d>
+  DEADLINE: <2026-01-30 Fri -3d>
+
+  This is a plain active timestamp in body text (it can show up in views):
+  <2026-01-22 Thu>
+
+  This is an inactive timestamp in body text (reference only):
+  [2026-01-22 Thu]
+
+# Optional: there is also a setting to treat only <...> as active for agenda scans.
+
+* [2026-01-15 Thu] LOGBOOK Drawer (State Change History) ----------------------------------------
+
+# 30) LOGBOOK
+# When enabled, completing tasks can record state-change history inside a drawer.
+# Settings:
+#   Org-vscode.logIntoDrawer
+#   Org-vscode.logDrawerName (default: LOGBOOK)
+
+* TODO Complete me to generate a LOGBOOK entry :LOGBOOK:
+  SCHEDULED: <2026-01-20>
+
+* DONE LOGBOOK example (pre-filled) :LOGBOOK:
+  CLOSED: [2026-01-17 Sat 19:09]
+  :LOGBOOK:
+  - State "DONE" from "TODO" [2026-01-17 Sat 19:09]
+  :END:
+  Notes under the drawer stay normal text.

--- a/examples/year-template.org
+++ b/examples/year-template.org
@@ -5,18 +5,18 @@
 ⊘ [01-02-2025 Thu] -------------------------------------------------------------------------------------------------------------------------------
     ⊖ DONE : [+TAG:PROJECT] - Completed the quarterly report
     ⊖ DONE : Team standup
-    ⊜ CONTINUED : [+TAG:PROJECT] - Database migration                                SCHEDULED: [01-03-2025]
+    ⊜ CONTINUED : [+TAG:PROJECT] - Database migration                                SCHEDULED: <01-03-2025>
 
 ⊘ [01-03-2025 Fri] -------------------------------------------------------------------------------------------------------------------------------
     ⊖ DONE : [+TAG:PROJECT] - Database migration
-      COMPLETED:[3rd January 2025, 4:15:22 pm]
-    ⊙ TODO : [+TAG:ADMIN] - Submit expense report                                    SCHEDULED: [01-06-2025]
+      CLOSED: [3rd January 2025, 4:15:22 pm]
+    ⊙ TODO : [+TAG:ADMIN] - Submit expense report                                    SCHEDULED: <01-06-2025>
     ⊖ DONE : [+TAG:MEETING] - Weekly sync with team
 
 ⊘ [01-06-2025 Mon] -------------------------------------------------------------------------------------------------------------------------------
     ⊖ DONE : [+TAG:ADMIN] - Submit expense report
-      COMPLETED:[6th January 2025, 10:30:00 am]
-    ⊘ IN_PROGRESS : [+TAG:LEARNING] - Complete online training module                SCHEDULED: [01-10-2025]
+      CLOSED: [6th January 2025, 10:30:00 am]
+    ⊘ IN_PROGRESS : [+TAG:LEARNING] - Complete online training module                SCHEDULED: <01-10-2025>
     ⊖ DONE : Review pull requests
 
 ⊘ [01-07-2025 Tue] -------------------------------------------------------------------------------------------------------------------------------
@@ -26,6 +26,6 @@
 
 ⊘ [01-10-2025 Fri] -------------------------------------------------------------------------------------------------------------------------------
     ⊖ DONE : [+TAG:LEARNING] - Complete online training module
-      COMPLETED:[10th January 2025, 3:45:00 pm]
+      CLOSED: [10th January 2025, 3:45:00 pm]
     ⊖ DONE : [+TAG:MEETING] - Sprint retrospective
-    ⊙ TODO : [+TAG:PROJECT] - Start new feature development                          SCHEDULED: [01-13-2025]
+    ⊙ TODO : [+TAG:PROJECT] - Start new feature development                          SCHEDULED: <01-13-2025>

--- a/org-vscode/out/moveUp.js
+++ b/org-vscode/out/moveUp.js
@@ -1,5 +1,5 @@
 const vscode = require("vscode");
-const { computeMoveBlockResult } = require("./moveBlockUtils");
+const { computeMoveBlockResult, computeMoveBlockRangeResult } = require("./moveBlockUtils");
 
 module.exports = async function () {
   const editor = vscode.window.activeTextEditor;
@@ -10,7 +10,15 @@ module.exports = async function () {
   const cursorChar = editor.selection.active.character;
   const lines = document.getText().split(/\r?\n/);
 
-  const result = computeMoveBlockResult(lines, cursorLine, "up");
+  const sel = editor.selection;
+  const hasRange = sel && !sel.isEmpty;
+  const selectionStartLine = hasRange ? Math.min(sel.start.line, sel.end.line) : cursorLine;
+  let selectionEndLine = hasRange ? Math.max(sel.start.line, sel.end.line) : cursorLine;
+  if (hasRange && sel.end.character === 0 && selectionEndLine > selectionStartLine) selectionEndLine -= 1;
+
+  const result = hasRange
+    ? computeMoveBlockRangeResult(lines, selectionStartLine, selectionEndLine, "up")
+    : computeMoveBlockResult(lines, cursorLine, "up");
   if (!result) return;
 
   const fullText = result.updatedLines.join("\n");
@@ -29,6 +37,18 @@ module.exports = async function () {
   const newLineText = result.updatedLines[newLine] || "";
   const newChar = Math.max(0, Math.min(cursorChar, newLineText.length));
   const newPos = new vscode.Position(newLine, newChar);
-  editor.selection = new vscode.Selection(newPos, newPos);
+
+  if (hasRange && typeof result.newSelectionStartLine === "number" && typeof result.newSelectionEndLineExclusive === "number") {
+    const startLine = Math.max(0, Math.min(result.updatedLines.length - 1, result.newSelectionStartLine));
+    const endLine = Math.max(0, Math.min(result.updatedLines.length, result.newSelectionEndLineExclusive));
+    const endLineInclusive = Math.max(0, endLine - 1);
+    const endChar = (result.updatedLines[endLineInclusive] || "").length;
+    editor.selection = new vscode.Selection(
+      new vscode.Position(startLine, 0),
+      new vscode.Position(endLineInclusive, endChar)
+    );
+  } else {
+    editor.selection = new vscode.Selection(newPos, newPos);
+  }
   editor.revealRange(new vscode.Range(newPos, newPos), vscode.TextEditorRevealType.InCenter);
 };

--- a/org-vscode/out/syntaxColorCustomizer.js
+++ b/org-vscode/out/syntaxColorCustomizer.js
@@ -168,6 +168,18 @@ const DEFAULT_COLORS = {
     background: "",
     fontStyle: ""
   },
+  "LOGBOOK Drawer": {
+    scope: "meta.drawer.logbook.content.vso",
+    foreground: "#9d9d9d",
+    background: "",
+    fontStyle: ""
+  },
+  "LOGBOOK Drawer Markers": {
+    scope: ["keyword.other.drawer.logbook.vso", "keyword.other.drawer.end.vso"],
+    foreground: "#6A9955",
+    background: "",
+    fontStyle: "bold"
+  },
   "Heading Level 1": {
     scope: "markup.heading.vso",
     foreground: "#dcdcaa",
@@ -326,7 +338,9 @@ const SCOPE_GROUPS = {
     "Heading Level 3",
     "Org Directive",
     "Property Drawer",
-    "Property Key"
+    "Property Key",
+    "LOGBOOK Drawer",
+    "LOGBOOK Drawer Markers"
   ],
   "Org Syntax": [
     "Link",
@@ -1816,6 +1830,8 @@ function getPreviewText(scopeName) {
     "Org Directive": "#+TITLE: Work",
     "Property Drawer": ":PROPERTIES: ... :END:",
     "Property Key": ":OWNER: Doug",
+    "LOGBOOK Drawer": "- State \"DONE\" from \"TODO\" [2026-01-17 Sat 19:09]",
+    "LOGBOOK Drawer Markers": ":LOGBOOK: ... :END:",
     "Heading Level 1": "* Heading",
     "Heading Level 2": "** Subheading",
     "Heading Level 3": "*** Detail",

--- a/org-vscode/test/unit/checkbox-auto-done.test.js
+++ b/org-vscode/test/unit/checkbox-auto-done.test.js
@@ -24,9 +24,23 @@ function testTransitionsMarkDoneAndRevertToInProgress() {
   assert.deepStrictEqual(toMarkInProgress, [4], 'Expected Task B to revert to IN_PROGRESS');
 }
 
+function testDoesNotAutoDoneWhenChildSubtaskIncomplete() {
+  const lines = [
+    '* IN_PROGRESS Parent',
+    '  - [X] one',
+    '  - [X] two',
+    '  ** TODO Child still todo',
+  ];
+
+  const { toMarkDone } = computeHeadingTransitions(lines);
+
+  assert.deepStrictEqual(toMarkDone, [], 'Expected Parent to NOT be marked DONE while a child task is still TODO');
+}
+
 module.exports = {
   name: 'unit/checkbox-auto-done',
   run: () => {
     testTransitionsMarkDoneAndRevertToInProgress();
+    testDoesNotAutoDoneWhenChildSubtaskIncomplete();
   }
 };

--- a/org-vscode/test/unit/checkbox-toggle.test.js
+++ b/org-vscode/test/unit/checkbox-toggle.test.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const path = require('path');
 
-const { computeCheckboxToggleEdits } = require(path.join(__dirname, '..', '..', 'out', 'checkboxToggle.js'));
+const { computeCheckboxToggleEdits, computeCheckboxBulkToggleEdits } = require(path.join(__dirname, '..', '..', 'out', 'checkboxToggle.js'));
 
 function applyEdits(lines, edits) {
   const out = lines.slice();
@@ -45,10 +45,40 @@ function testToggleParentTogglesDescendants() {
   assert.strictEqual(updated[4], '  - [ ] Sibling');
 }
 
+function testBulkToggleChecksWhenAnyUnchecked() {
+  const lines = [
+    '* H',
+    '  - [ ] a',
+    '  - [X] b',
+  ];
+
+  const edits = computeCheckboxBulkToggleEdits(lines, [1, 2]);
+  const updated = applyEdits(lines, edits);
+
+  assert.strictEqual(updated[1], '  - [X] a');
+  assert.strictEqual(updated[2], '  - [X] b');
+}
+
+function testBulkToggleUnchecksWhenAllChecked() {
+  const lines = [
+    '* H',
+    '  - [X] a',
+    '  - [X] b',
+  ];
+
+  const edits = computeCheckboxBulkToggleEdits(lines, [1, 2]);
+  const updated = applyEdits(lines, edits);
+
+  assert.strictEqual(updated[1], '  - [ ] a');
+  assert.strictEqual(updated[2], '  - [ ] b');
+}
+
 module.exports = {
   name: 'unit/checkbox-toggle',
   run: () => {
     testToggleLeafUpdatesAncestors();
     testToggleParentTogglesDescendants();
+    testBulkToggleChecksWhenAnyUnchecked();
+    testBulkToggleUnchecksWhenAllChecked();
   }
 };

--- a/org-vscode/test/unit/set-todo-state.test.js
+++ b/org-vscode/test/unit/set-todo-state.test.js
@@ -232,7 +232,7 @@ function testAllRepeaterUnits() {
 function testCatchUpFromYearsAgo() {
   const registry = createDefaultRegistry();
 
-  // ++1d from 2020 should catch up to tomorrow (relative to today)
+  // ++1d from 2020 should catch up to today or later (relative to today)
   const result = computeTodoStateChange({
     currentLineText: "* TODO Test",
     nextLineText: "  SCHEDULED: <2020-01-01 Wed ++1d>",
@@ -244,10 +244,10 @@ function testCatchUpFromYearsAgo() {
     workflowRegistry: registry
   });
 
-  // The date should be in the future (after today)
+  // The date should not be in the past (>= today)
   const outDate = result.mergedPlanning.scheduled.split(" ")[0];
   const today = new Date().toISOString().split("T")[0];
-  assert.ok(outDate > today, `Catch-up ++1d from 2020 should be after today (${today}), got ${outDate}`);
+  assert.ok(outDate >= today, `Catch-up ++1d from 2020 should be on/after today (${today}), got ${outDate}`);
   assert.ok(result.mergedPlanning.scheduled.includes("++1d"), "Should preserve ++1d repeater");
 }
 

--- a/org-vscode/vso.tmLanguage.json
+++ b/org-vscode/vso.tmLanguage.json
@@ -50,6 +50,9 @@
       ]
     },
     {
+      "include": "#logbook_drawer"
+    },
+    {
       "name": "meta.task.in_progress.vso",
       "comment": "In Progress Task (asterisk heading)",
       "begin": "^\\s*\\*+\\s+(?=IN_PROGRESS\\b)",
@@ -211,11 +214,11 @@
     },
     {
       "name": "constant.numeric.date.vso",
-      "match": "\\[(?:\\d{4}-\\d{2}-\\d{2}|\\d{2}-\\d{2}-\\d{4})(?:\\s+\\w{3})?(?:\\s+\\d{1,2}:\\d{2})?(?:\\s+[^\\]]+)?\\]"
+      "match": "(?:\\[(?:\\d{4}-\\d{2}-\\d{2}|\\d{2}-\\d{2}-\\d{4})(?:\\s+\\w{3})?(?:\\s+\\d{1,2}:\\d{2}(?:-\\d{1,2}:\\d{2})?)?(?:\\s+[^\\]]+)?\\])|(?:<(?:\\d{4}-\\d{2}-\\d{2}|\\d{2}-\\d{2}-\\d{4})(?:\\s+\\w{3})?(?:\\s+\\d{1,2}:\\d{2}(?:-\\d{1,2}:\\d{2})?)?(?:\\s+[^>]+)?>)"
     },
     {
       "name": "constant.numeric.date.header.vso",
-      "match": "\\[(?:\\d{4}-\\d{2}-\\d{2}|\\d{2}-\\d{2}-\\d{4})\\s+\\w{3}(?:\\s+\\d{1,2}:\\d{2})?(?:\\s+[^\\]]+)?\\]"
+      "match": "(?:\\[(?:\\d{4}-\\d{2}-\\d{2}|\\d{2}-\\d{2}-\\d{4})\\s+\\w{3}(?:\\s+\\d{1,2}:\\d{2}(?:-\\d{1,2}:\\d{2})?)?(?:\\s+[^\\]]+)?\\])|(?:<(?:\\d{4}-\\d{2}-\\d{2}|\\d{2}-\\d{2}-\\d{4})\\s+\\w{3}(?:\\s+\\d{1,2}:\\d{2}(?:-\\d{1,2}:\\d{2})?)?(?:\\s+[^>]+)?>)"
     },
     {
       "name": "markup.heading.vso",
@@ -641,7 +644,13 @@
       "patterns": [
         {
           "name": "keyword.scheduled.vso",
-          "match": "SCHEDULED:\\s*\\[(?:\\d{4}-\\d{2}-\\d{2}|\\d{2}-\\d{2}-\\d{4})(?:\\s+\\w{3})?(?:\\s+\\d{1,2}:\\d{2})?(?:\\s+[^\\]]+)?\\]"
+          "match": "\\b(SCHEDULED:)(\\s*)([<\\[])((?:\\d{4}-\\d{2}-\\d{2}|\\d{2}-\\d{2}-\\d{4})(?:\\s+\\w{3})?(?:\\s+\\d{1,2}:\\d{2}(?:-\\d{1,2}:\\d{2})?)?(?:\\s+[^>\\]]+)?)([>\\]])",
+          "captures": {
+            "1": { "name": "keyword.scheduled.vso" },
+            "3": { "name": "punctuation.definition.timestamp.begin.vso" },
+            "4": { "name": "constant.numeric.date.vso" },
+            "5": { "name": "punctuation.definition.timestamp.end.vso" }
+          }
         }
       ]
     },
@@ -649,7 +658,13 @@
       "patterns": [
         {
           "name": "markup.deleted.deadline.vso",
-          "match": "DEADLINE:\\s*\\[(?:\\d{4}-\\d{2}-\\d{2}|\\d{2}-\\d{2}-\\d{4})(?:\\s+\\w{3})?(?:\\s+\\d{1,2}:\\d{2})?(?:\\s+[^\\]]+)?\\]"
+          "match": "\\b(DEADLINE:)(\\s*)([<\\[])((?:\\d{4}-\\d{2}-\\d{2}|\\d{2}-\\d{2}-\\d{4})(?:\\s+\\w{3})?(?:\\s+\\d{1,2}:\\d{2}(?:-\\d{1,2}:\\d{2})?)?(?:\\s+[^>\\]]+)?)([>\\]])",
+          "captures": {
+            "1": { "name": "markup.deleted.deadline.vso" },
+            "3": { "name": "punctuation.definition.timestamp.begin.vso" },
+            "4": { "name": "constant.numeric.date.vso" },
+            "5": { "name": "punctuation.definition.timestamp.end.vso" }
+          }
         }
       ]
     },
@@ -657,7 +672,33 @@
       "patterns": [
         {
           "name": "keyword.closed.vso",
-          "match": "^\\s*(?:CLOSED|COMPLETED):\\s*\\[(?:\\d{4}-\\d{2}-\\d{2}|\\d{2}-\\d{2}-\\d{4})(?:\\s+\\w{3})?(?:\\s+\\d{1,2}:\\d{2})?(?:\\s+[^\\]]+)?\\]"
+          "match": "^\\s*(CLOSED|COMPLETED):\\s*([<\\[])(?:\\d{4}-\\d{2}-\\d{2}|\\d{2}-\\d{2}-\\d{4})(?:\\s+\\w{3})?(?:\\s+\\d{1,2}:\\d{2}(?:-\\d{1,2}:\\d{2})?)?(?:\\s+[^>\\]]+)?([>\\]])",
+          "captures": {
+            "1": { "name": "keyword.closed.vso" },
+            "2": { "name": "punctuation.definition.timestamp.begin.vso" },
+            "3": { "name": "punctuation.definition.timestamp.end.vso" }
+          }
+        }
+      ]
+    },
+    "logbook_drawer": {
+      "patterns": [
+        {
+          "name": "meta.drawer.logbook.vso",
+          "begin": "^(\\s*)(:LOGBOOK:)\\s*$",
+          "beginCaptures": {
+            "2": { "name": "keyword.other.drawer.logbook.vso" }
+          },
+          "end": "^(\\s*)(:END:)\\s*$",
+          "endCaptures": {
+            "2": { "name": "keyword.other.drawer.end.vso" }
+          },
+          "contentName": "meta.drawer.logbook.content.vso",
+          "patterns": [
+            { "include": "#timestamp" },
+            { "name": "keyword.other.logbook.state.vso", "match": "\\bState\\b" },
+            { "name": "string.quoted.double.logbook.vso", "match": "\"[^\"]*\"" }
+          ]
         }
       ]
     },
@@ -721,7 +762,7 @@
     },
     "sched": {
       "patterns": [
-        { "name": "keyword.closed.vso", "match": "^\\s*(?:CLOSED|COMPLETED):\\s*\\[.*?\\]" }
+        { "name": "keyword.closed.vso", "match": "^\\s*(?:CLOSED|COMPLETED):\\s*[<\\[].*?[>\\]]" }
       ]
     },
     "abandoned": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "org-vscode",
 	"displayName": "org-vscode",
 	"description": "Quickly create todo lists, take notes, plan projects and organize your thoughts.",
-	"version": "2.2.9",
+	"version": "2.2.10",
 	"repository": "https://www.github.com/realDestroyer/org-vscode",
 	"icon": "Images/org-vscode-logo.png",
 	"publisher": "realDestroyer",

--- a/vso.tmLanguage.json
+++ b/vso.tmLanguage.json
@@ -50,6 +50,9 @@
       ]
     },
     {
+      "include": "#logbook_drawer"
+    },
+    {
       "name": "meta.task.in_progress.vso",
       "comment": "In Progress Task (asterisk heading)",
       "begin": "^\\s*\\*+\\s+(?=IN_PROGRESS\\b)",
@@ -211,11 +214,11 @@
     },
     {
       "name": "constant.numeric.date.vso",
-      "match": "\\[(?:\\d{4}-\\d{2}-\\d{2}|\\d{2}-\\d{2}-\\d{4})(?:\\s+\\w{3})?(?:\\s+\\d{1,2}:\\d{2})?(?:\\s+[^\\]]+)?\\]"
+      "match": "(?:\\[(?:\\d{4}-\\d{2}-\\d{2}|\\d{2}-\\d{2}-\\d{4})(?:\\s+\\w{3})?(?:\\s+\\d{1,2}:\\d{2}(?:-\\d{1,2}:\\d{2})?)?(?:\\s+[^\\]]+)?\\])|(?:<(?:\\d{4}-\\d{2}-\\d{2}|\\d{2}-\\d{2}-\\d{4})(?:\\s+\\w{3})?(?:\\s+\\d{1,2}:\\d{2}(?:-\\d{1,2}:\\d{2})?)?(?:\\s+[^>]+)?>)"
     },
     {
       "name": "constant.numeric.date.header.vso",
-      "match": "\\[(?:\\d{4}-\\d{2}-\\d{2}|\\d{2}-\\d{2}-\\d{4})\\s+\\w{3}(?:\\s+\\d{1,2}:\\d{2})?(?:\\s+[^\\]]+)?\\]"
+      "match": "(?:\\[(?:\\d{4}-\\d{2}-\\d{2}|\\d{2}-\\d{2}-\\d{4})\\s+\\w{3}(?:\\s+\\d{1,2}:\\d{2}(?:-\\d{1,2}:\\d{2})?)?(?:\\s+[^\\]]+)?\\])|(?:<(?:\\d{4}-\\d{2}-\\d{2}|\\d{2}-\\d{2}-\\d{4})\\s+\\w{3}(?:\\s+\\d{1,2}:\\d{2}(?:-\\d{1,2}:\\d{2})?)?(?:\\s+[^>]+)?>)"
     },
     {
       "name": "markup.heading.vso",
@@ -641,7 +644,13 @@
       "patterns": [
         {
           "name": "keyword.scheduled.vso",
-          "match": "SCHEDULED:\\s*\\[(?:\\d{4}-\\d{2}-\\d{2}|\\d{2}-\\d{2}-\\d{4})(?:\\s+\\w{3})?(?:\\s+\\d{1,2}:\\d{2})?(?:\\s+[^\\]]+)?\\]"
+          "match": "\\b(SCHEDULED:)(\\s*)([<\\[])((?:\\d{4}-\\d{2}-\\d{2}|\\d{2}-\\d{2}-\\d{4})(?:\\s+\\w{3})?(?:\\s+\\d{1,2}:\\d{2}(?:-\\d{1,2}:\\d{2})?)?(?:\\s+[^>\\]]+)?)([>\\]])",
+          "captures": {
+            "1": { "name": "keyword.scheduled.vso" },
+            "3": { "name": "punctuation.definition.timestamp.begin.vso" },
+            "4": { "name": "constant.numeric.date.vso" },
+            "5": { "name": "punctuation.definition.timestamp.end.vso" }
+          }
         }
       ]
     },
@@ -649,7 +658,13 @@
       "patterns": [
         {
           "name": "markup.deleted.deadline.vso",
-          "match": "DEADLINE:\\s*\\[(?:\\d{4}-\\d{2}-\\d{2}|\\d{2}-\\d{2}-\\d{4})(?:\\s+\\w{3})?(?:\\s+\\d{1,2}:\\d{2})?(?:\\s+[^\\]]+)?\\]"
+          "match": "\\b(DEADLINE:)(\\s*)([<\\[])((?:\\d{4}-\\d{2}-\\d{2}|\\d{2}-\\d{2}-\\d{4})(?:\\s+\\w{3})?(?:\\s+\\d{1,2}:\\d{2}(?:-\\d{1,2}:\\d{2})?)?(?:\\s+[^>\\]]+)?)([>\\]])",
+          "captures": {
+            "1": { "name": "markup.deleted.deadline.vso" },
+            "3": { "name": "punctuation.definition.timestamp.begin.vso" },
+            "4": { "name": "constant.numeric.date.vso" },
+            "5": { "name": "punctuation.definition.timestamp.end.vso" }
+          }
         }
       ]
     },
@@ -657,7 +672,33 @@
       "patterns": [
         {
           "name": "keyword.closed.vso",
-          "match": "^\\s*(?:CLOSED|COMPLETED):\\s*\\[(?:\\d{4}-\\d{2}-\\d{2}|\\d{2}-\\d{2}-\\d{4})(?:\\s+\\w{3})?(?:\\s+\\d{1,2}:\\d{2})?(?:\\s+[^\\]]+)?\\]"
+          "match": "^\\s*(CLOSED|COMPLETED):\\s*([<\\[])(?:\\d{4}-\\d{2}-\\d{2}|\\d{2}-\\d{2}-\\d{4})(?:\\s+\\w{3})?(?:\\s+\\d{1,2}:\\d{2}(?:-\\d{1,2}:\\d{2})?)?(?:\\s+[^>\\]]+)?([>\\]])",
+          "captures": {
+            "1": { "name": "keyword.closed.vso" },
+            "2": { "name": "punctuation.definition.timestamp.begin.vso" },
+            "3": { "name": "punctuation.definition.timestamp.end.vso" }
+          }
+        }
+      ]
+    },
+    "logbook_drawer": {
+      "patterns": [
+        {
+          "name": "meta.drawer.logbook.vso",
+          "begin": "^(\\s*)(:LOGBOOK:)\\s*$",
+          "beginCaptures": {
+            "2": { "name": "keyword.other.drawer.logbook.vso" }
+          },
+          "end": "^(\\s*)(:END:)\\s*$",
+          "endCaptures": {
+            "2": { "name": "keyword.other.drawer.end.vso" }
+          },
+          "contentName": "meta.drawer.logbook.content.vso",
+          "patterns": [
+            { "include": "#timestamp" },
+            { "name": "keyword.other.logbook.state.vso", "match": "\\bState\\b" },
+            { "name": "string.quoted.double.logbook.vso", "match": "\"[^\"]*\"" }
+          ]
         }
       ]
     },
@@ -721,7 +762,7 @@
     },
     "sched": {
       "patterns": [
-        { "name": "keyword.closed.vso", "match": "^\\s*(?:CLOSED|COMPLETED):\\s*\\[.*?\\]" }
+        { "name": "keyword.closed.vso", "match": "^\\s*(?:CLOSED|COMPLETED):\\s*[<\\[].*?[>\\]]" }
       ]
     },
     "abandoned": {


### PR DESCRIPTION
This PR rolls up recent fixes/enhancements and prepares the 2.2.10 release.

Highlights
- Fix Agenda/Tagged Agenda deadline parsing to avoid "Due: Invalid date" and add deadline badges for fast scanning.
- Fix Set Repeater output (avoid malformed planning like `SCHEDULED: [< ...]`).
- Improve Migrate File to v2:
  - Convert legacy planning `SCHEDULED/DEADLINE: [...]` to active `<...>` and repair malformed `[< ...]`.
  - Ensure inline planning stamps are moved to the canonical planning line.
- Multi-line selection support:
  - `Ctrl+Alt+X` bulk toggles checkbox items (check-all / uncheck-all).
  - Move Block Up/Down supports multi-line selections.
- Checkbox auto-DONE correctness:
  - Parent tasks only auto-complete when all checkboxes are checked AND no child task headings remain incomplete.
  - Repeating tasks: completion logs (if enabled), applies repeater, reopens, clears CLOSED, and resets subtree (checkboxes + child subtasks) for next iteration.

Docs + release prep
- Docs updated to match v2 planning stamp conventions (`SCHEDULED/DEADLINE: <...>`, `CLOSED: [...]`) and new selection behaviors.
- Version bumped to 2.2.10 and VSIX packaged.

Issues
Fixes #82
Fixes #83
Fixes #84
Fixes #85
Fixes #86
Fixes #87
Fixes #88
