### PR TITLE
Fix CLOSED stamping when reopening tasks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,14 @@
 - (none)
 
 
+# [2.2.13] 01-23-26
+
+`Fixed`
+
+- **Reopening tasks no longer stamps CLOSED:** Transitions from done-like states (e.g. `DONE`) back to non-done states (e.g. `TODO`) no longer insert a `CLOSED: [...]` timestamp.
+  - `CLOSED` stamping is now gated on both `isDoneLike` and `stampsClosed` for consistent behavior across state cycling and Set TODO State.
+
+
 # [2.2.12] 01-20-26
 
 `Added / Enhanced`

--- a/org-vscode/out/keywordLeft.js
+++ b/org-vscode/out/keywordLeft.js
@@ -100,7 +100,7 @@ module.exports = async function () {
     const cleanedText = taskKeywordManager.cleanTaskText(headlineNoPlanning);
     const { keyword: rotatedKeyword } = taskKeywordManager.rotateKeyword(currentKeyword, "left");
     const completionTransition = workflowRegistry.isDoneLike(rotatedKeyword) && !workflowRegistry.isDoneLike(currentKeyword);
-    const completionStampsClosed = workflowRegistry.stampsClosed(rotatedKeyword);
+    const completionStampsClosed = workflowRegistry.isDoneLike(rotatedKeyword) && workflowRegistry.stampsClosed(rotatedKeyword);
 
     const completionTimestamp = moment().format(`${dateFormat} ddd HH:mm`);
 

--- a/org-vscode/out/keywordRight.js
+++ b/org-vscode/out/keywordRight.js
@@ -100,7 +100,7 @@ module.exports = async function () {
     const cleanedText = taskKeywordManager.cleanTaskText(headlineNoPlanning);
     const { keyword: rotatedKeyword } = taskKeywordManager.rotateKeyword(currentKeyword, "right");
     const completionTransition = workflowRegistry.isDoneLike(rotatedKeyword) && !workflowRegistry.isDoneLike(currentKeyword);
-    const completionStampsClosed = workflowRegistry.stampsClosed(rotatedKeyword);
+    const completionStampsClosed = workflowRegistry.isDoneLike(rotatedKeyword) && workflowRegistry.stampsClosed(rotatedKeyword);
 
     const completionTimestamp = moment().format(`${dateFormat} ddd HH:mm`);
 

--- a/org-vscode/out/setTodoState.js
+++ b/org-vscode/out/setTodoState.js
@@ -72,7 +72,7 @@ function computeTodoStateChange(params) {
   }
 
   if (effectiveKeyword === targetKeyword) {
-    if (workflowRegistry.stampsClosed(targetKeyword)) {
+    if (workflowRegistry.isDoneLike(targetKeyword) && workflowRegistry.stampsClosed(targetKeyword)) {
       mergedPlanning.closed = moment().format(`${dateFormat} ddd HH:mm`);
     } else if (workflowRegistry.stampsClosed(currentKeyword)) {
       mergedPlanning.closed = null;
@@ -253,7 +253,7 @@ async function setTodoState() {
           originalFile,
           cleanedText,
           nextKeyword: effectiveKeyword,
-          stampsClosed: workflowRegistry.stampsClosed(effectiveKeyword),
+          stampsClosed: workflowRegistry.isDoneLike(effectiveKeyword) && workflowRegistry.stampsClosed(effectiveKeyword),
           headingMarkerStyle
         });
       }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "org-vscode",
 	"displayName": "org-vscode",
 	"description": "Quickly create todo lists, take notes, plan projects and organize your thoughts.",
-	"version": "2.2.12",
+	"version": "2.2.13",
 	"repository": "https://www.github.com/realDestroyer/org-vscode",
 	"icon": "Images/org-vscode-logo.png",
 	"publisher": "realDestroyer",


### PR DESCRIPTION
Fixes #93 
- Prevents CLOSED: timestamps from being stamped when transitioning into non-done states (e.g. TODO).
- Applies consistently across Set TODO State and keyword cycling (left/right).
- Adds unit regression coverage.