### PR TITLE
Docs: add feature candidates from EMACS Org Mode 

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -9,6 +9,7 @@ These are the features that I have either already implemented, or plan to in the
 | Feature Name              | Description                                                                                | Progress    | Version  | Author        |
 | ------------------------- | ------------------------------------------------------------------------------------------ | ----------- | -------- | ------------- |
 | Agenda View: deadlines + undated | Agenda View includes DEADLINE-only tasks and an optional (default-on) `[UNDATED]` section for tasks with no dates. | DONE | v2.2.14 | realDestroyer |
+| Agenda View: recently closed | Add an Agenda View tab/filter that shows recently completed tasks, bucketed by `CLOSED` date (daily groups). Should interpret `CLOSED:` stamps and LOGBOOK entries for repeated tasks so the most recent completion is used. | Not Started |  | realDestroyer |
 | Embedded Query Blocks | Support an in-file `#+BEGIN_QUERY ... #+END_QUERY` block that renders a live/updatable list of matching headings (workspace-wide) into the preview (Org-QL/Dataview-style). | Not Started |  | realDestroyer |
 | Workspace Index Cache (Optional) | Optional on-disk index (JSON/SQLite) to speed up link completion, tag/title lookup, symbol search, and query blocks; should be gitignored by default. | Not Started |  | realDestroyer |
 | Context Action: Ctrl+C Ctrl+C | Add a context-aware command that “does the right thing” at point (toggle checkbox, follow link, update timestamp, etc.), similar to Emacs Org’s `C-c C-c`. | Not Started |  | realDestroyer |
@@ -28,7 +29,7 @@ These are the features that I have either already implemented, or plan to in the
 | Smart TAB folding behavior | Context-aware folding across headings/lists/blocks/properties (Emacs-style feel) | Not Started | v2.3.0 | realDestroyer |
 | Insert link utilities | Insert link command + richer link editing utilities | Not Started | v2.3.0 | realDestroyer |
 | LOGBOOK drawer logging | Optional Org-style state-change history entries written into a drawer (default: `LOGBOOK`) on completion transitions. | DONE | v2.2.9 | realDestroyer |
-| Agenda View performance | Improve Agenda View load times on large `.org` files (faster parsing + caching + lazy rendering). | In Progress | v2.2.9 | realDestroyer |
+| Agenda View performance | Improve Agenda View load times on large `.org` files (faster parsing + caching + lazy rendering). | DONE | v2.2.9 | realDestroyer |
 | Repeating tasks (Org repeaters) | Support Org repeaters on `SCHEDULED:` / `DEADLINE:` (`+`, `++`, `.+`) and optional `REPEAT_TO_STATE` reopen behavior (with inheritance). | DONE | v2.2.8 | realDestroyer |
 | Auto-indent non-heading text (Issue #76) | Optional auto-indentation of body/planning lines on Enter (configurable indentation width); see https://github.com/realDestroyer/org-vscode/issues/76 | DONE | v2.2.6 | realDestroyer |
 | Property management commands | Set/update properties, auto-create drawers, inherited lookup (local → parents → file `#+PROPERTY`), and ID helper commands | DONE | v2.2.4 | realDestroyer |


### PR DESCRIPTION
Updates the roadmap:
- Mark Agenda View performance as DONE (v2.2.9)
- Add backlog item for an Agenda View tab showing recently completed tasks bucketed by CLOSED date (with LOGBOOK support for repeats)
- Includes other backlog feature candidates

Kept docs-only to stay separate from the Smart Date bugfix PR (#100).