### PR TITLE
Fix child tasks in Agenda + Tagged Agenda

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,14 @@
 - (none)
 
 
+# [2.2.19] 02-12-26
+
+`Fixed`
+
+- **Agenda View: child tasks with their own dates are no longer skipped:** Child task headings with their own `SCHEDULED` / `DEADLINE` are now surfaced even when their parent task is included in the agenda and the subtree is otherwise skipped.
+- **Tagged Agenda View: child task rows render correctly in “Show Details”:** Child task headings inside the details block no longer inherit the main row float layout.
+
+
 # [2.2.19] 02-09-26
 
 `Fixed`

--- a/org-vscode/out/taggedAgenda.js
+++ b/org-vscode/out/taggedAgenda.js
@@ -1187,6 +1187,24 @@ body{
         .detail-line.subtask-line .taskText {
           margin-left: 6px;
         }
+
+        /* Child task rows inside Show Details should not inherit the main row float layout. */
+        .children-block .taskText {
+          float: none;
+          width: auto;
+          margin-top: 0;
+          font-family: monospace;
+        }
+        .children-block .todo,
+        .children-block .done,
+        .children-block .in_progress,
+        .children-block .continued,
+        .children-block .abandoned {
+          float: none;
+          padding-top: 0;
+          height: auto;
+          display: inline-block;
+        }
         #error-banner {
           margin: 0 0 12px;
           padding: 10px 14px;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "org-vscode",
-	"version": "2.2.18",
+	"version": "2.2.19",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "org-vscode",
-			"version": "2.2.18",
+			"version": "2.2.19",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "org-vscode",
 	"displayName": "org-vscode",
 	"description": "Quickly create todo lists, take notes, plan projects and organize your thoughts.",
-	"version": "2.2.18",
+	"version": "2.2.19",
 	"repository": "https://www.github.com/realDestroyer/org-vscode",
 	"icon": "Images/org-vscode-logo.png",
 	"publisher": "realDestroyer",


### PR DESCRIPTION
Fixes #105.

- Agenda: surface dated child task headings even when a parent task is included (and the subtree would otherwise be skipped).
- Tagged Agenda: child task rows in "Show Details" no longer inherit float layout, so they render correctly.

Version bump: 2.2.19
