### PR TITLE
Fix done task auto-move sibling scope

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,34 @@
+# Copilot Instructions
+
+This repository ships a VS Code extension. Follow these rules when making changes:
+
+## Where to edit
+
+- Edit extension source in `org-vscode/out/`.
+- Add or update tests in `org-vscode/test/`.
+- Treat `dist/extension.js` as generated output. Rebuild it from source with `npm run bundle` instead of editing it manually.
+
+## Workflow expectations
+
+- Prefer working from an Issue and a dedicated branch off `master`.
+- Keep fixes narrow and behavior-focused.
+- For bug fixes, add a regression test when practical.
+- Target PRs at `master` and reference the issue with `Fixes #<issue>` or equivalent.
+
+## Validation
+
+- If runtime logic changes, run `npm run bundle`.
+- Validate with the narrowest useful test, and use `node .\org-vscode\test\runTest.js` or `npm test` when extension behavior is affected.
+
+## Privacy and fixtures
+
+- Do not commit personal Org tasks or real private work items.
+- Do not use content from `Test Org Files/` directly in committed tests or docs.
+- Convert reproductions into generic fixtures under tests or `examples/`.
+- Use neutral sample text such as `Parent A`, `Parent B`, `Example task`, and `Duplicate task`.
+
+## Change style
+
+- Match the existing code style.
+- Avoid unrelated refactors.
+- Prefer root-cause fixes over surface workarounds.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# AI Agent Instructions
+
+These instructions apply to coding agents working in this repository, including GPT-style agents and Claude-style agents.
+
+## Repository layout
+
+- Root package and published extension manifest: `package.json`
+- Editable extension source used for bundling: `org-vscode/out/`
+- Extension tests: `org-vscode/test/`
+- Bundled runtime artifact: `dist/extension.js`
+- Example/sample content belongs in `examples/` or synthetic test fixtures, not in personal Org files.
+
+## Workflow
+
+1. Start from an Issue when practical.
+2. Create a branch from `master`.
+   - Preferred names: `fix/<short-description>-<issue#>` or `feature/<short-description>-<issue#>`
+3. Keep changes scoped to the Issue.
+4. Run focused validation before finishing.
+5. Open a PR targeting `master` and link the Issue with `Fixes #<issue>` or equivalent.
+
+## Codebase rules
+
+- Do not hand-edit `dist/extension.js` unless there is no alternative. Update source under `org-vscode/out/` and rebuild.
+- If runtime code changes, run `npm run bundle` from the repository root.
+- Prefer adding regression coverage in `org-vscode/test/` when fixing behavior bugs.
+- Use generic task names and synthetic Org content in tests.
+- Preserve existing public behavior unless the Issue specifically requires a change.
+
+## Privacy and sample-data rules
+
+- Never commit personal TODOs, real work items, private file paths, or sensitive Org content from `Test Org Files/`.
+- Do not copy personal tasks into tests, issue writeups, PR descriptions, screenshots, or docs.
+- Replace real content with neutral examples such as `Parent A`, `Parent B`, `Duplicate task`, or similar synthetic fixtures.
+- If reproducing a bug discovered in a personal Org file, translate it into a generic minimal example before committing.
+
+## Validation commands
+
+From the repository root:
+
+- `npm run bundle`
+- `node .\org-vscode\test\runTest.js`
+- `npm test`
+- `npm run test:unit`
+
+Use the narrowest command that validates the touched area, but ensure at least one executable validation runs before finishing when code changes.
+
+## PR hygiene
+
+- Keep commits focused and reviewable.
+- Mention behavior change and validation performed.
+- Keep PR examples generic and privacy-safe.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# Claude Instructions
+
+Follow the repository-wide instructions in `AGENTS.md`.
+
+Priority guidance:
+
+- Treat `AGENTS.md` as the canonical workflow and privacy policy for this repository.
+- If you change runtime logic, edit source in `org-vscode/out/` and rebuild with `npm run bundle`.
+- Add regression tests in `org-vscode/test/` when fixing behavior bugs.
+- Never commit personal Org tasks or copy content from `Test Org Files/` into tests, docs, issues, PRs, or release notes.
+- Use generic fixtures and examples only.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,10 @@
+# Gemini Instructions
+
+Follow the repository-wide instructions in `AGENTS.md`.
+
+Priority guidance:
+
+- `AGENTS.md` is the source of truth for repository workflow and release-safe behavior.
+- Use generic synthetic fixtures in tests and docs.
+- Do not commit personal task data from local Org files.
+- Rebuild and test after runtime changes.

--- a/GROK.md
+++ b/GROK.md
@@ -1,0 +1,10 @@
+# Grok Instructions
+
+Follow the repository-wide instructions in `AGENTS.md`.
+
+Priority guidance:
+
+- Use `AGENTS.md` as the canonical instructions file for workflow, validation, and privacy.
+- Make source edits in `org-vscode/out/`, not in generated bundle artifacts unless absolutely necessary.
+- Keep examples and regressions generic; do not commit personal Org content.
+- Validate executable changes before finishing.

--- a/org-vscode/out/doneTaskAutoMove.js
+++ b/org-vscode/out/doneTaskAutoMove.js
@@ -29,6 +29,10 @@ function parseHeadingLevel(lineText, config) {
   const indent = (mStar ? mStar[1] : mUnicode[1]) || "";
   const starsLen = mStar ? ((mStar[2] || "").length || 0) : 0;
 
+  if (mStar) {
+    return starsLen > 0 ? starsLen : null;
+  }
+
   const spacesPerLevel = getSpacesPerLevel(config);
   const indentLevel = (spacesPerLevel > 0)
     ? (Math.floor(indent.length / spacesPerLevel) + 1)
@@ -77,15 +81,34 @@ function isDoneLikeHeadingLine(lineText, registry) {
 
 function findLineIndexNear(lines, approxIndex, targetLineText, radius = 60) {
   if (!targetLineText) return -1;
-  const start = Math.max(0, Math.min(lines.length - 1, approxIndex) - radius);
-  const end = Math.min(lines.length - 1, Math.min(lines.length - 1, approxIndex) + radius);
-  for (let i = start; i <= end; i++) {
+  const center = Math.max(0, Math.min(lines.length - 1, approxIndex));
+  for (let distance = 0; distance <= radius; distance++) {
+    const before = center - distance;
+    if (before >= 0 && lines[before] === targetLineText) return before;
+
+    if (distance === 0) continue;
+
+    const after = center + distance;
+    if (after < lines.length && lines[after] === targetLineText) return after;
+  }
+  return -1;
+}
+
+function findLineIndexInSiblingScope(lines, approxHeading, targetLineText, config) {
+  if (!approxHeading || approxHeading.level === null || !targetLineText) return -1;
+
+  const parent = findParentHeadingAbove(lines, approxHeading.line, approxHeading.level, config);
+  const scopeStartLine = parent ? (parent.line + 1) : 0;
+  const scopeEndExclusive = parent
+    ? findSubtreeEndExclusive(lines, parent.line, parent.level, config)
+    : lines.length;
+
+  for (let i = scopeStartLine; i < scopeEndExclusive; i++) {
+    const level = parseHeadingLevel(lines[i], config);
+    if (level !== approxHeading.level) continue;
     if (lines[i] === targetLineText) return i;
   }
-  // Fallback: scan whole document (rare; used when previous edits shifted far).
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i] === targetLineText) return i;
-  }
+
   return -1;
 }
 
@@ -128,15 +151,19 @@ async function applyAutoMoveDoneInternal(document, approxLineIndex, expectedHead
 
   const text = document.getText();
   const lines = text.split(/\r?\n/);
+  const approximateHeading = findNearestHeadingAtOrAbove(lines, approxLineIndex, config);
 
   let headingLineIndex = -1;
   if (expectedHeadingLineText) {
-    headingLineIndex = findLineIndexNear(lines, approxLineIndex, expectedHeadingLineText);
+    headingLineIndex = findLineIndexNear(lines, approxLineIndex, expectedHeadingLineText, 120);
+    if (headingLineIndex < 0) {
+      headingLineIndex = findLineIndexInSiblingScope(lines, approximateHeading, expectedHeadingLineText, config);
+    }
   }
 
   const heading = (headingLineIndex >= 0)
     ? { line: headingLineIndex, level: parseHeadingLevel(lines[headingLineIndex], config) }
-    : findNearestHeadingAtOrAbove(lines, approxLineIndex, config);
+    : approximateHeading;
 
   if (!heading || heading.level === null) {
     return returnNewLineNumber ? { applied: false, newLineNumber: null } : false;
@@ -332,15 +359,19 @@ function computeAutoMoveDoneEdit(document, approxLineIndex, expectedHeadingLineT
 
   const text = document.getText();
   const lines = text.split(/\r?\n/);
+  const approximateHeading = findNearestHeadingAtOrAbove(lines, approxLineIndex, config);
 
   let headingLineIndex = -1;
   if (expectedHeadingLineText) {
-    headingLineIndex = findLineIndexNear(lines, approxLineIndex, expectedHeadingLineText);
+    headingLineIndex = findLineIndexNear(lines, approxLineIndex, expectedHeadingLineText, 120);
+    if (headingLineIndex < 0) {
+      headingLineIndex = findLineIndexInSiblingScope(lines, approximateHeading, expectedHeadingLineText, config);
+    }
   }
 
   const heading = (headingLineIndex >= 0)
     ? { line: headingLineIndex, level: parseHeadingLevel(lines[headingLineIndex], config) }
-    : findNearestHeadingAtOrAbove(lines, approxLineIndex, config);
+    : approximateHeading;
 
   if (!heading || heading.level === null) return null;
   if (!isDoneLikeHeadingLine(lines[heading.line], registry)) return null;

--- a/org-vscode/test/suite/asterisk-mode-functional.test.js
+++ b/org-vscode/test/suite/asterisk-mode-functional.test.js
@@ -127,6 +127,74 @@ suite('Asterisk-mode functional behavior', function () {
     }
   });
 
+  test('Auto-move done stays in the local sibling group when heading text is duplicated', async () => {
+    const cfg = vscode.workspace.getConfiguration('Org-vscode');
+    const workflowBefore = cfg.inspect('workflowStates') || {};
+    const sortBefore = cfg.inspect('sortClosedTasksToTop') || {};
+    const oldGlobalWorkflowStates = workflowBefore.globalValue;
+    const oldGlobalSortClosedTasksToTop = sortBefore.globalValue;
+
+    await cfg.update(
+      'workflowStates',
+      [
+        { keyword: 'TODO' },
+        { keyword: 'IN_PROGRESS' },
+        { keyword: 'DONE', isDoneLike: true, stampsClosed: true }
+      ],
+      vscode.ConfigurationTarget.Global
+    );
+    await cfg.update('sortClosedTasksToTop', true, vscode.ConfigurationTarget.Global);
+
+    await waitFor(() => {
+      const updatedWorkflowStates = vscode.workspace.getConfiguration('Org-vscode').get('workflowStates');
+      const sortClosedTasksToTop = vscode.workspace.getConfiguration('Org-vscode').get('sortClosedTasksToTop');
+      return (
+        Array.isArray(updatedWorkflowStates) &&
+        updatedWorkflowStates.length === 3 &&
+        updatedWorkflowStates[2] &&
+        updatedWorkflowStates[2].keyword === 'DONE' &&
+        sortClosedTasksToTop === true
+      );
+    });
+
+    try {
+      const contents = [
+        '  * TODO Parent A',
+        '  ** TODO Before A',
+        '  ** DONE Duplicate task',
+        '  * TODO Parent B',
+        '  ** DONE Existing done B',
+        '  ** IN_PROGRESS Duplicate task',
+        '  ** TODO After B',
+        ''
+      ].join('\n');
+
+      const uri = await writeTempVsoFile(contents);
+      const { doc, editor } = await openFileInEditor(uri);
+      setCursor(editor, 5, 0);
+
+      await vscode.commands.executeCommand('extension.toggleStatusRight');
+
+      await waitFor(() => {
+        const text = doc.getText();
+        return /  \* TODO Parent B\r?\n  \*\* DONE Existing done B\r?\n  \*\* DONE Duplicate task\r?\n\s+CLOSED: \[.*\]\r?\n  \*\* TODO After B/.test(text);
+      });
+
+      const out = doc.getText();
+      assert.ok(
+        /  \* TODO Parent A\r?\n  \*\* TODO Before A\r?\n  \*\* DONE Duplicate task/.test(out),
+        `Parent A should remain unchanged. Document was:\n${out}`
+      );
+      assert.ok(
+        /  \* TODO Parent B\r?\n  \*\* DONE Existing done B\r?\n  \*\* DONE Duplicate task\r?\n\s+CLOSED: \[.*\]\r?\n  \*\* TODO After B/.test(out),
+        `Completed task should move only within Parent B. Document was:\n${out}`
+      );
+    } finally {
+      await cfg.update('workflowStates', oldGlobalWorkflowStates, vscode.ConfigurationTarget.Global);
+      await cfg.update('sortClosedTasksToTop', oldGlobalSortClosedTasksToTop, vscode.ConfigurationTarget.Global);
+    }
+  });
+
   test('CONTINUED forwards to next day and removal cleans it up', async () => {
     const separator = ' -------------------------------------------------------------------------------------------------------------------------------';
     const contents = [


### PR DESCRIPTION
﻿Fixes #112

## Summary

- fix done-task auto-move so completed headings stay in the correct local sibling group
- add a regression test for duplicated child heading text in indented asterisk files
- add repository agent instructions for Copilot and general GPT/Claude-style coding agents

## Validation

- npm run bundle
- node .\org-vscode\test\runTest.js

## Privacy

- committed fixtures and PR text use only generic sample tasks
- no personal Org tasks or private work items were copied into the branch
