### PR TITLE
Workflow keywords on checkboxes and custom state syntax colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Org-vscode helps you manage tasks, notes, and projects in plain text `.org` file
 	- Agenda View includes scheduled tasks, deadline-only tasks, and an optional (default-on) `[UNDATED]` section for tasks with no dates
 	- Agenda View includes a **Closed** tab (recently completed tasks grouped by completion date) and a **Range** filter (All / This week / This month / This year)
 - Checklists with hierarchical parent/child checkbox states
+- Workflow keywords on checkbox items (`- [ ] TODO ...`) that rotate in place with `Ctrl + →` / `Ctrl + ←`
 - Org-mode statistics cookies: `[/]` (fraction) and `[%]` (percent)
 - Subtree completion stats on headings (TODO subtree completion + checkbox completion)
 - Emphasis rendering for `*bold*`, `/italic/`, `_underline_`, `+strike+`
@@ -51,6 +52,7 @@ Org-vscode helps you manage tasks, notes, and projects in plain text `.org` file
 - Org table generator (command + snippets)
 - Reports/tools: Export Current Tasks, Export Yearly Summary, Executive Report, Year-In-Review Dashboard
 - Customization: Syntax Color Customizer (colors + Workflow States editor) + settings for heading markers / indentation / decorations
+- Custom workflow states get their own syntax color options in the Syntax Color Customizer, applied immediately after saving
 - Commands: Sort Headings by Scheduled Date (`Org-vscode.sortClosedTasksToTop` optional)
 - **External Capture & Link API** (opt-in, off by default): other VS Code extensions can register custom org link schemes (e.g. `[[msgid:abc@host]]`) and push structured TODO entries into your inbox after a per-extension consent prompt. There's also a built-in **Org-vscode: Capture TODO into Inbox** palette command for quick personal capture. See [docs/external-api.md](docs/external-api.md), the runnable [examples/external-consumer/](examples/external-consumer/README.md), and [SECURITY.md](SECURITY.md).
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,14 @@
 
 `Added / Enhanced`
 
-- (none)
+- **Workflow keywords on checkboxes:** Checkbox list items can now carry a workflow keyword (for example `- [ ] TODO Draft the plan`). `Ctrl + Right` / `Ctrl + Left` rotates the keyword in place instead of treating the line as a heading, preserving the bullet and `[ ]` marker. The cycle includes a "no keyword" step so keywords can be removed again, and rotating into a state that stamps `CLOSED` checks the box (states that are done-like but don't stamp `CLOSED`, like `ABANDONED`, leave it alone). Checkbox keywords are never counted as task headings by Agenda, Tagged Agenda, or subtree TODO statistics. Controlled by `Org-vscode.enableCheckboxKeywords`.
+- **Syntax coloring for custom workflow states:** User-defined workflow states now get their own Symbol / Keyword / Task Text rows in the Syntax Color Customizer, grouped as `<KEYWORD> Tasks (custom)`. New states appear immediately after clicking **Save Workflow** — no window reload. Because the bundled grammar can't know runtime keywords, custom-state colors are applied via editor decorations driven by the same saved settings (`Org-vscode.decorateCustomWorkflowStates`). Each custom state starts from a distinct default color.
+- **Built-in keywords on checkbox lines are syntax highlighted:** The grammar now scopes workflow keywords that follow a checkbox marker in ordered and unordered lists.
+
+`Tests`
+
+- Added `checkbox-keywords` unit coverage (parsing, keyword rotation, checkbox-state syncing, custom workflows, no-keyword removal step).
+- Added `workflow-state-scopes` unit coverage (built-in vs custom scope mapping, slug sanitization, generated customizer rows, deduplication).
 
 
 # [2.2.28] 08-13-26

--- a/docs/howto.md
+++ b/docs/howto.md
@@ -681,6 +681,30 @@ In both Agenda View and Tagged Agenda View:
 
 <img src="https://github.com/realdestroyer/org-vscode/blob/master/Images/checkbox-taggedAgenda-example.png?raw=true" width="900" />
 
+### Workflow keywords on checkboxes
+
+Checkbox items can carry their own workflow keyword, so a single checklist entry can track progress without being promoted to a heading:
+
+```org
+- [ ] TODO Draft the migration plan
+- [ ] IN_PROGRESS Review with the team
+- [X] DONE Ship it
+```
+
+Place the cursor on a checkbox line and press `Ctrl + →` / `Ctrl + ←` to rotate the keyword in place. The bullet and `[ ]` marker stay exactly where they are.
+
+Behavior:
+
+- The cycle includes a **"no keyword"** step, so you can always remove a keyword again.
+- Rotating into a state that stamps `CLOSED` (by default `DONE`) checks the box.
+- Rotating back out of that state unchecks the box.
+- States that are done-like but do **not** stamp `CLOSED` (by default `ABANDONED`) leave the box untouched, because abandoning an item is not the same as completing it.
+- Your custom workflow states work here too.
+
+Checkbox keywords are deliberately **not** treated as task headings: they never appear in Agenda View, Tagged Agenda View, or subtree TODO statistics. They remain ordinary checkbox items for checkbox counting.
+
+Set `Org-vscode.enableCheckboxKeywords` to `false` to disable this and restore the previous behavior.
+
 ---
 
 ## ⏰ Deadlines <a id="deadlines"></a>
@@ -1239,8 +1263,22 @@ Elements are grouped for easy navigation:
 * **CONTINUED Tasks** - Symbol, keyword, and task text
 * **DONE Tasks** - Symbol, keyword, and task text
 * **ABANDONED Tasks** - Symbol, keyword, and task text
+* **&lt;YOUR_STATE&gt; Tasks (custom)** - one group per user-defined workflow state
 * **Heading Decorations** - Heading SCHEDULED / DEADLINE suffix styling
 * **Other Elements** - SCHEDULED/DEADLINE/CLOSED stamps, inline tags, agenda dates, property drawers
+
+#### 🎛 Coloring your custom workflow states <a id="coloring-custom-workflow-states"></a>
+
+States you create on the **Workflow States** tab automatically get their own Symbol / Keyword / Task Text color rows.
+
+1. Open the **Workflow States** tab and add a state (for example `EXAMPLE_STATE`).
+2. Click **💾 Save Workflow**.
+3. The **Syntax Colors** tab immediately gains an **EXAMPLE_STATE Tasks (custom)** group — no window reload required.
+4. Pick your colors and click **💾 Save Colors**.
+
+Because the bundled TextMate grammar is static, it cannot know keywords you invent at runtime. Custom-state colors are therefore applied with editor decorations driven by the exact same saved settings. This is controlled by `Org-vscode.decorateCustomWorkflowStates` (on by default); turning it off leaves custom keywords uncolored.
+
+Each new custom state starts from a distinct default color so multiple custom states are easy to tell apart at a glance.
 
 #### 💾 Save & Reset <a id="save-and-reset"></a>
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,6 +8,8 @@ These are the features that I have either already implemented, or plan to in the
 
 | Feature Name              | Description                                                                                | Progress    | Version  | Author        |
 | ------------------------- | ------------------------------------------------------------------------------------------ | ----------- | -------- | ------------- |
+| Workflow keywords on checkboxes | Allow checkbox list items to carry a workflow keyword (`- [ ] TODO ...`) and rotate it in place with `Ctrl + Right` / `Ctrl + Left`, including a "no keyword" step and checkbox-state syncing on completion. | DONE | Unreleased | realDestroyer |
+| Syntax coloring for custom workflow states | Generate Symbol / Keyword / Task Text color rows for user-defined workflow states in the Syntax Color Customizer, applied immediately after saving via editor decorations. | DONE | Unreleased | realDestroyer |
 | External Capture & Link API | Public API surface (`registerLinkType`, `captureTodo`) so third-party extensions (email clients, ticket trackers, browsers) can push structured TODO entries into the inbox and register custom org link schemes. Off by default with per-extension consent prompts. Addresses [#110](https://github.com/realDestroyer/org-vscode/issues/110). | DONE | v2.2.26 | realDestroyer |
 | Column View (MVP) | Open a task table with sortable/filterable columns, inherited Org properties, and scope modes (global/file/subtree). | DONE | v2.2.24 | realDestroyer |
 | Agenda panel placement preservation | Keep Agenda View in its current panel/editor group when auto-refreshing after file save. | DONE | v2.2.24 | realDestroyer |

--- a/org-vscode/out/checkboxKeywords.js
+++ b/org-vscode/out/checkboxKeywords.js
@@ -1,0 +1,131 @@
+"use strict";
+
+// Workflow keywords on checkbox list items, e.g. `- [ ] TODO Write the spec`.
+// Kept separate from heading keyword detection so checkbox keywords are never
+// counted as task headings by Agenda, Tagged Agenda, or subtree statistics.
+
+// Groups: 1=indent, 2=bullet, 3=space, 4=state char, 5=space, 6=rest
+const CHECKBOX_ITEM_REGEX = /^(\s*)([-+*]|\d+[.)])(\s+)\[( |x|X|-)\](\s+)(.*)$/;
+
+function escapeRegExp(text) {
+  return String(text).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function getCycleKeywords(registry) {
+  if (!registry || typeof registry.getCycleKeywords !== "function") return [];
+  const cycle = registry.getCycleKeywords();
+  return Array.isArray(cycle) ? cycle.filter((k) => typeof k === "string" && k.trim()) : [];
+}
+
+function buildLeadingKeywordRegex(registry) {
+  const keywords = getCycleKeywords(registry);
+  if (!keywords.length) return null;
+  const alternation = keywords.map(escapeRegExp).join("|");
+  return new RegExp(`^(${alternation})\\b[ \\t]*`);
+}
+
+function isCheckboxLine(line) {
+  return CHECKBOX_ITEM_REGEX.test(String(line == null ? "" : line));
+}
+
+/**
+ * Splits a checkbox line into its structural parts plus any leading workflow keyword.
+ * Returns null when the line is not a checkbox item.
+ */
+function parseCheckboxLine(line, registry) {
+  const match = String(line == null ? "" : line).match(CHECKBOX_ITEM_REGEX);
+  if (!match) return null;
+
+  const rest = match[6] || "";
+  const keywordRegex = buildLeadingKeywordRegex(registry);
+
+  let keyword = null;
+  let text = rest;
+
+  if (keywordRegex) {
+    const keywordMatch = rest.match(keywordRegex);
+    if (keywordMatch) {
+      keyword = String(keywordMatch[1]).toUpperCase();
+      text = rest.slice(keywordMatch[0].length);
+    }
+  }
+
+  return {
+    indent: match[1] || "",
+    bullet: match[2] || "-",
+    spaceAfterBullet: match[3] || " ",
+    state: match[4] || " ",
+    spaceAfterBox: match[5] || " ",
+    keyword,
+    text
+  };
+}
+
+function findCheckboxKeyword(line, registry) {
+  const parsed = parseCheckboxLine(line, registry);
+  return parsed ? parsed.keyword : null;
+}
+
+function buildCheckboxLine(parts) {
+  const safe = parts && typeof parts === "object" ? parts : {};
+  const indent = safe.indent || "";
+  const bullet = safe.bullet || "-";
+  const spaceAfterBullet = safe.spaceAfterBullet || " ";
+  const state = safe.state || " ";
+  const spaceAfterBox = safe.spaceAfterBox || " ";
+  const text = safe.text == null ? "" : String(safe.text);
+  const keyword = safe.keyword ? String(safe.keyword).toUpperCase() : null;
+
+  const body = keyword ? (text ? `${keyword} ${text}` : keyword) : text;
+  return `${indent}${bullet}${spaceAfterBullet}[${state}]${spaceAfterBox}${body}`;
+}
+
+/**
+ * Rotates the workflow keyword on a checkbox item.
+ *
+ * The ring includes a "no keyword" slot so a keyword can be removed again.
+ * The checkbox marker is synced only for states that stamp CLOSED, so
+ * abandoning an item does not mark it complete.
+ */
+function rotateCheckboxKeyword(line, direction, registry) {
+  const parsed = parseCheckboxLine(line, registry);
+  if (!parsed) return null;
+
+  const cycle = getCycleKeywords(registry);
+  if (!cycle.length) return null;
+
+  const ring = [null].concat(cycle);
+  const foundIndex = parsed.keyword ? ring.indexOf(parsed.keyword) : 0;
+  const currentIndex = foundIndex === -1 ? 0 : foundIndex;
+  const step = direction === "left" ? -1 : 1;
+  const nextIndex = (currentIndex + step + ring.length) % ring.length;
+  const nextKeyword = ring[nextIndex];
+
+  const completes = (keyword) =>
+    Boolean(keyword && registry && typeof registry.stampsClosed === "function" && registry.stampsClosed(keyword));
+
+  const wasComplete = completes(parsed.keyword);
+  const willBeComplete = completes(nextKeyword);
+
+  let state = parsed.state;
+  if (willBeComplete && !wasComplete) state = "X";
+  else if (!willBeComplete && wasComplete) state = " ";
+
+  const text = buildCheckboxLine({ ...parsed, keyword: nextKeyword, state });
+
+  return {
+    previousKeyword: parsed.keyword,
+    keyword: nextKeyword,
+    changed: text !== String(line == null ? "" : line),
+    text
+  };
+}
+
+module.exports = {
+  CHECKBOX_ITEM_REGEX,
+  isCheckboxLine,
+  parseCheckboxLine,
+  findCheckboxKeyword,
+  buildCheckboxLine,
+  rotateCheckboxKeyword
+};

--- a/org-vscode/out/customStateDecorations.js
+++ b/org-vscode/out/customStateDecorations.js
@@ -1,0 +1,271 @@
+"use strict";
+
+const vscode = require("vscode");
+const taskKeywordManager = require("./taskKeywordManager");
+const checkboxKeywords = require("./checkboxKeywords");
+const { getScopesForKeyword, isBuiltinStateKeyword } = require("./workflowStateScopes");
+
+// User-defined workflow keywords cannot be added to the static TextMate grammar,
+// so their Syntax Color Customizer settings are applied as editor decorations.
+
+function normalizeScopes(scope) {
+  if (!scope) return [];
+  const list = Array.isArray(scope) ? scope : [scope];
+  return list
+    .flatMap((entry) => String(entry).split(","))
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function createTokenColorResolver() {
+  const config = vscode.workspace.getConfiguration();
+  const customizations = config.get("editor.tokenColorCustomizations") || {};
+  const rules = Array.isArray(customizations.textMateRules) ? customizations.textMateRules : [];
+
+  return {
+    getSettingsForScope(scope) {
+      if (!scope) return null;
+      for (const rule of rules) {
+        const scopes = normalizeScopes(rule && rule.scope);
+        if (!scopes.includes(scope)) continue;
+        const settings = (rule && rule.settings) || {};
+        return {
+          foreground: typeof settings.foreground === "string" ? settings.foreground.trim() : "",
+          background: typeof settings.background === "string" ? settings.background.trim() : "",
+          fontStyle: typeof settings.fontStyle === "string" ? settings.fontStyle.trim() : ""
+        };
+      }
+      return null;
+    }
+  };
+}
+
+function toDecorationOptions(settings) {
+  if (!settings || !settings.foreground) return null;
+  const options = { color: settings.foreground };
+  if (settings.background) options.backgroundColor = settings.background;
+  if (settings.fontStyle) {
+    if (settings.fontStyle.includes("bold")) options.fontWeight = "bold";
+    if (settings.fontStyle.includes("italic")) options.fontStyle = "italic";
+    if (settings.fontStyle.includes("underline")) options.textDecoration = "underline";
+  }
+  return options;
+}
+
+function getCustomStates(registry) {
+  return (registry && Array.isArray(registry.states) ? registry.states : [])
+    .filter((state) => state && state.keyword && !isBuiltinStateKeyword(state.keyword));
+}
+
+function shouldDecorate(editor) {
+  if (!editor || !editor.document) return false;
+  if (editor.document.languageId !== "vso") return false;
+  const config = vscode.workspace.getConfiguration("Org-vscode");
+  return Boolean(config.get("decorateCustomWorkflowStates", true));
+}
+
+function isHeadingLine(text, registry) {
+  const value = String(text || "");
+  if (/^\s*\*+\s+\S/.test(value)) return true;
+  const markers = (registry && Array.isArray(registry.states) ? registry.states : [])
+    .map((state) => state && state.marker)
+    .filter((marker) => typeof marker === "string" && marker.length > 0);
+  return markers.some((marker) => value.trimStart().startsWith(marker));
+}
+
+/**
+ * Locates the keyword, marker, and trailing text ranges for custom states on a line.
+ * Returns null when the line carries no custom-state keyword.
+ */
+function computeLineParts(text, registry) {
+  const value = String(text || "");
+
+  if (checkboxKeywords.isCheckboxLine(value)) {
+    const keyword = checkboxKeywords.findCheckboxKeyword(value, registry);
+    if (!keyword || isBuiltinStateKeyword(keyword)) return null;
+    const keywordStart = value.indexOf(keyword);
+    if (keywordStart === -1) return null;
+    return {
+      keyword,
+      markerStart: -1,
+      markerEnd: -1,
+      keywordStart,
+      keywordEnd: keywordStart + keyword.length,
+      textStart: keywordStart + keyword.length,
+      textEnd: value.length
+    };
+  }
+
+  if (!isHeadingLine(value, registry)) return null;
+
+  const keyword = taskKeywordManager.findTaskKeyword(value);
+  if (!keyword || isBuiltinStateKeyword(keyword)) return null;
+
+  const keywordStart = value.indexOf(keyword);
+  if (keywordStart === -1) return null;
+
+  const state = (registry.states || []).find((s) => s && s.keyword === keyword);
+  const marker = state && typeof state.marker === "string" ? state.marker : "";
+  const markerStart = marker ? value.indexOf(marker) : -1;
+
+  return {
+    keyword,
+    markerStart,
+    markerEnd: markerStart === -1 ? -1 : markerStart + marker.length,
+    keywordStart,
+    keywordEnd: keywordStart + keyword.length,
+    textStart: keywordStart + keyword.length,
+    textEnd: value.length
+  };
+}
+
+function registerCustomStateDecorations(ctx) {
+  // Unit tests mock vscode; skip decoration wiring when the API isn't present.
+  if (!vscode.window || typeof vscode.window.createTextEditorDecorationType !== "function") {
+    return;
+  }
+
+  /** @type {Map<string, { symbol?: any, keyword?: any, taskText?: any }>} */
+  const decorationTypes = new Map();
+  let pendingTimer = null;
+
+  function disposeTypes() {
+    for (const group of decorationTypes.values()) {
+      for (const type of Object.values(group)) {
+        try {
+          type.dispose();
+        } catch (_) {
+          // ignore
+        }
+      }
+    }
+    decorationTypes.clear();
+  }
+
+  function rebuildDecorationTypes(registry) {
+    disposeTypes();
+
+    const resolver = createTokenColorResolver();
+
+    for (const state of getCustomStates(registry)) {
+      const descriptor = getScopesForKeyword(state.keyword);
+      if (!descriptor) continue;
+
+      const group = {};
+      for (const part of ["symbol", "keyword", "taskText"]) {
+        const options = toDecorationOptions(resolver.getSettingsForScope(descriptor.scopes[part]));
+        if (!options) continue;
+        group[part] = vscode.window.createTextEditorDecorationType(options);
+      }
+
+      if (Object.keys(group).length) {
+        decorationTypes.set(descriptor.keyword, group);
+        for (const type of Object.values(group)) {
+          ctx.subscriptions.push(type);
+        }
+      }
+    }
+  }
+
+  function clearEditor(editor) {
+    if (!editor) return;
+    for (const group of decorationTypes.values()) {
+      for (const type of Object.values(group)) {
+        editor.setDecorations(type, []);
+      }
+    }
+  }
+
+  function apply(editor) {
+    if (!editor) return;
+
+    if (!shouldDecorate(editor)) {
+      clearEditor(editor);
+      return;
+    }
+
+    const registry = taskKeywordManager.getWorkflowRegistry();
+    rebuildDecorationTypes(registry);
+    if (!decorationTypes.size) return;
+
+    /** @type {Map<any, any[]>} */
+    const rangesByType = new Map();
+    for (const group of decorationTypes.values()) {
+      for (const type of Object.values(group)) {
+        rangesByType.set(type, []);
+      }
+    }
+
+    const doc = editor.document;
+    const visible = (editor.visibleRanges && editor.visibleRanges.length)
+      ? editor.visibleRanges
+      : [new vscode.Range(new vscode.Position(0, 0), new vscode.Position(Math.max(0, doc.lineCount - 1), 0))];
+
+    for (const visibleRange of visible) {
+      const startLine = Math.max(0, visibleRange.start.line);
+      const endLine = Math.min(doc.lineCount - 1, visibleRange.end.line);
+
+      for (let line = startLine; line <= endLine; line++) {
+        const text = doc.lineAt(line).text;
+        const parts = computeLineParts(text, registry);
+        if (!parts) continue;
+
+        const group = decorationTypes.get(parts.keyword);
+        if (!group) continue;
+
+        if (group.symbol && parts.markerStart !== -1) {
+          rangesByType.get(group.symbol).push(new vscode.Range(line, parts.markerStart, line, parts.markerEnd));
+        }
+        if (group.keyword) {
+          rangesByType.get(group.keyword).push(new vscode.Range(line, parts.keywordStart, line, parts.keywordEnd));
+        }
+        if (group.taskText && parts.textEnd > parts.textStart) {
+          rangesByType.get(group.taskText).push(new vscode.Range(line, parts.textStart, line, parts.textEnd));
+        }
+      }
+    }
+
+    for (const [type, ranges] of rangesByType.entries()) {
+      editor.setDecorations(type, ranges);
+    }
+  }
+
+  function scheduleApply(editor) {
+    if (pendingTimer) clearTimeout(pendingTimer);
+    pendingTimer = setTimeout(() => {
+      pendingTimer = null;
+      apply(editor || vscode.window.activeTextEditor);
+    }, 50);
+  }
+
+  scheduleApply(vscode.window.activeTextEditor);
+
+  ctx.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor((editor) => scheduleApply(editor)),
+    vscode.window.onDidChangeTextEditorVisibleRanges((event) => {
+      if (event.textEditor === vscode.window.activeTextEditor) {
+        scheduleApply(event.textEditor);
+      }
+    }),
+    vscode.workspace.onDidChangeTextDocument((event) => {
+      const active = vscode.window.activeTextEditor;
+      if (active && event.document.uri.toString() === active.document.uri.toString()) {
+        scheduleApply(active);
+      }
+    }),
+    vscode.workspace.onDidChangeConfiguration((event) => {
+      if (
+        event.affectsConfiguration("Org-vscode.decorateCustomWorkflowStates") ||
+        event.affectsConfiguration("Org-vscode.workflowStates") ||
+        event.affectsConfiguration("editor.tokenColorCustomizations")
+      ) {
+        scheduleApply(vscode.window.activeTextEditor);
+      }
+    })
+  );
+}
+
+module.exports = {
+  registerCustomStateDecorations,
+  computeLineParts
+};

--- a/org-vscode/out/extension.js
+++ b/org-vscode/out/extension.js
@@ -49,6 +49,7 @@ const { openSyntaxColorCustomizer } = require("./syntaxColorCustomizer");
 const { openKeybindingCustomizer } = require("./keybindingCustomizer");
 const { registerUnicodeHeadingDecorations } = require("./unicodeHeadingDecorations");
 const { registerTodoLineDecorations } = require("./todoLineDecorations");
+const { registerCustomStateDecorations } = require("./customStateDecorations");
 const { registerCheckboxAutoDone } = require("./checkboxAutoDone");
 const { registerCheckboxStatsDecorations } = require("./checkboxStatsDecorations");
 const { registerMarkupCommands } = require("./markupCommands");
@@ -201,6 +202,9 @@ function activate(ctx) {
 
   // Whole-line task state highlighting (uses the user's token color customizations for background colors)
   registerTodoLineDecorations(ctx);
+
+  // Color user-defined workflow keywords (the static grammar can't know them)
+  registerCustomStateDecorations(ctx);
 
   // Automatically mark tasks DONE when all checkboxes are checked
   registerCheckboxAutoDone(ctx);

--- a/org-vscode/out/keywordLeft.js
+++ b/org-vscode/out/keywordLeft.js
@@ -11,6 +11,7 @@ const { computeLogbookInsertion, formatStateChangeEntry } = require("./orgLogboo
 const { normalizeBodyIndentation } = require("./indentUtils");
 const { applyAutoMoveDone } = require("./doneTaskAutoMove");
 const { findIncompleteChildTask } = require("./todoDependencies");
+const checkboxKeywords = require("./checkboxKeywords");
 
 function buildPlanningBody(planning) {
   const parts = [];
@@ -34,6 +35,7 @@ module.exports = async function () {
   const logIntoDrawer = config.get("logIntoDrawer", false);
   const logDrawerName = config.get("logDrawerName", "LOGBOOK");
   const enforceTodoDependencies = config.get("enforceTodoDependencies", false);
+  const enableCheckboxKeywords = config.get("enableCheckboxKeywords", true);
   const workflowRegistry = taskKeywordManager.getWorkflowRegistry();
 
   const { document } = activeTextEditor;
@@ -69,6 +71,17 @@ module.exports = async function () {
 
   for (const lineNumber of sortedLines) {
     const currentLine = document.lineAt(lineNumber);
+
+    if (enableCheckboxKeywords && checkboxKeywords.isCheckboxLine(currentLine.text)) {
+      const rotated = checkboxKeywords.rotateCheckboxKeyword(currentLine.text, "left", workflowRegistry);
+      if (rotated && rotated.changed) {
+        const checkboxEdit = new vscode.WorkspaceEdit();
+        checkboxEdit.replace(document.uri, currentLine.range, rotated.text);
+        await vscode.workspace.applyEdit(checkboxEdit);
+      }
+      continue;
+    }
+
     const nextLine = lineNumber + 1 < document.lineCount ? document.lineAt(lineNumber + 1) : null;
     const nextNextLine = lineNumber + 2 < document.lineCount ? document.lineAt(lineNumber + 2) : null;
 

--- a/org-vscode/out/keywordRight.js
+++ b/org-vscode/out/keywordRight.js
@@ -11,6 +11,7 @@ const { computeLogbookInsertion, formatStateChangeEntry } = require("./orgLogboo
 const { normalizeBodyIndentation } = require("./indentUtils");
 const { applyAutoMoveDone } = require("./doneTaskAutoMove");
 const { findIncompleteChildTask } = require("./todoDependencies");
+const checkboxKeywords = require("./checkboxKeywords");
 
 function buildPlanningBody(planning) {
   const parts = [];
@@ -34,6 +35,7 @@ module.exports = async function () {
   const logIntoDrawer = config.get("logIntoDrawer", false);
   const logDrawerName = config.get("logDrawerName", "LOGBOOK");
   const enforceTodoDependencies = config.get("enforceTodoDependencies", false);
+  const enableCheckboxKeywords = config.get("enableCheckboxKeywords", true);
   const workflowRegistry = taskKeywordManager.getWorkflowRegistry();
 
   const { document } = activeTextEditor;
@@ -69,6 +71,17 @@ module.exports = async function () {
 
   for (const lineNumber of sortedLines) {
     const currentLine = document.lineAt(lineNumber);
+
+    if (enableCheckboxKeywords && checkboxKeywords.isCheckboxLine(currentLine.text)) {
+      const rotated = checkboxKeywords.rotateCheckboxKeyword(currentLine.text, "right", workflowRegistry);
+      if (rotated && rotated.changed) {
+        const checkboxEdit = new vscode.WorkspaceEdit();
+        checkboxEdit.replace(document.uri, currentLine.range, rotated.text);
+        await vscode.workspace.applyEdit(checkboxEdit);
+      }
+      continue;
+    }
+
     const nextLine = lineNumber + 1 < document.lineCount ? document.lineAt(lineNumber + 1) : null;
     const nextNextLine = lineNumber + 2 < document.lineCount ? document.lineAt(lineNumber + 2) : null;
 

--- a/org-vscode/out/syntaxColorCustomizer.js
+++ b/org-vscode/out/syntaxColorCustomizer.js
@@ -8,6 +8,7 @@
 
 const vscode = require("vscode");
 const workflowStates = require("./workflowStates");
+const { buildCustomStateColorEntries } = require("./workflowStateScopes");
 const { html, escapeText } = require("./htmlUtils");
 
 // Default color definitions matching the extension's configurationDefaults.
@@ -464,6 +465,31 @@ const SCOPE_GROUPS = {
 let customizerPanel = null;
 
 /**
+ * Merges the static defaults with generated entries for user-defined workflow states.
+ */
+function buildColorDefinitions(states) {
+  const custom = buildCustomStateColorEntries(states);
+  return {
+    colors: { ...DEFAULT_COLORS, ...custom.colors },
+    groups: { ...SCOPE_GROUPS, ...custom.groups }
+  };
+}
+
+function renderCustomizerPanel() {
+  if (!customizerPanel) return;
+  const nonce = getNonce();
+  const currentWorkflowStates = getCurrentWorkflowStates();
+  const definitions = buildColorDefinitions(currentWorkflowStates.states);
+  const currentColors = getCurrentColors(definitions.colors);
+  customizerPanel.webview.html = getWebviewContent(
+    nonce,
+    currentColors,
+    currentWorkflowStates,
+    definitions.groups
+  );
+}
+
+/**
  * Opens the Syntax Color Customizer webview panel
  */
 function openSyntaxColorCustomizer() {
@@ -485,10 +511,11 @@ function openSyntaxColorCustomizer() {
   const nonce = getNonce();
   
   // Load current user settings
-  const currentColors = getCurrentColors();
   const currentWorkflowStates = getCurrentWorkflowStates();
+  const definitions = buildColorDefinitions(currentWorkflowStates.states);
+  const currentColors = getCurrentColors(definitions.colors);
   
-  customizerPanel.webview.html = getWebviewContent(nonce, currentColors, currentWorkflowStates);
+  customizerPanel.webview.html = getWebviewContent(nonce, currentColors, currentWorkflowStates, definitions.groups);
 
   customizerPanel.webview.onDidReceiveMessage(async (message) => {
     try {
@@ -499,10 +526,8 @@ function openSyntaxColorCustomizer() {
           break;
         case "saveWorkflowStates":
           await saveWorkflowStates(message.states);
-          customizerPanel.webview.postMessage({
-            command: "workflowStatesUpdated",
-            payload: getCurrentWorkflowStates()
-          });
+          // Rebuild so newly added custom states immediately get color rows.
+          renderCustomizerPanel();
           vscode.window.showInformationMessage("Workflow states saved successfully!");
           break;
         case "resetToDefaults":
@@ -510,16 +535,13 @@ function openSyntaxColorCustomizer() {
           // Send updated colors back to webview
           customizerPanel.webview.postMessage({
             command: "colorsUpdated",
-            colors: DEFAULT_COLORS
+            colors: buildColorDefinitions(getCurrentWorkflowStates().states).colors
           });
           vscode.window.showInformationMessage("Colors reset to defaults!");
           break;
         case "resetWorkflowStatesToDefaults":
           await resetWorkflowStatesToDefaults();
-          customizerPanel.webview.postMessage({
-            command: "workflowStatesUpdated",
-            payload: getCurrentWorkflowStates()
-          });
+          renderCustomizerPanel();
           vscode.window.showInformationMessage("Workflow states reset to defaults!");
           break;
         case "openKeyboardShortcuts":
@@ -543,13 +565,13 @@ function openSyntaxColorCustomizer() {
 /**
  * Gets the current color settings from user configuration
  */
-function getCurrentColors() {
+function getCurrentColors(baseColors) {
   const config = vscode.workspace.getConfiguration("editor");
   const tokenColors = config.get("tokenColorCustomizations") || {};
   const textMateRules = tokenColors.textMateRules || [];
 
   // Start with defaults, overlay user customizations
-  const colors = JSON.parse(JSON.stringify(DEFAULT_COLORS));
+  const colors = JSON.parse(JSON.stringify(baseColors || DEFAULT_COLORS));
 
   const normalizeHex6 = (value) => {
     if (value === undefined || value === null) return "";
@@ -783,7 +805,9 @@ function getNonce() {
 /**
  * Generates the webview HTML content
  */
-function getWebviewContent(nonce, currentColors, currentWorkflowStates) {
+function getWebviewContent(nonce, currentColors, currentWorkflowStates, scopeGroups) {
+  const groupDefinitions = scopeGroups || SCOPE_GROUPS;
+
   function escapeCssAttrValue(value) {
     return String(value || "").replace(/\\/g, "\\\\").replace(/\"/g, "\\\"");
   }
@@ -800,9 +824,10 @@ function getWebviewContent(nonce, currentColors, currentWorkflowStates) {
 
   let previewCss = "";
 
-  const groupsHtml = Object.entries(SCOPE_GROUPS).map(([groupName, scopeNames]) => {
+  const groupsHtml = Object.entries(groupDefinitions).map(([groupName, scopeNames]) => {
     const scopesHtml = scopeNames.map(name => {
       const settings = currentColors[name];
+      if (!settings) return "";
       const technicalScope = Array.isArray(settings.scope) ? settings.scope.join(", ") : settings.scope;
       const supportsBackground =
         /\bKeyword\b/.test(name) ||
@@ -2161,7 +2186,17 @@ function getPreviewText(scopeName) {
     "Emphasis Underline": "_underline_",
     "Emphasis Strike": "+strike+"
   };
-  return previews[scopeName] || scopeName;
+  if (previews[scopeName]) return previews[scopeName];
+
+  // User-defined workflow states get generated rows, so derive a preview from the label.
+  const custom = String(scopeName || "").match(/^(.+) (Symbol|Keyword|Task Text)$/);
+  if (custom) {
+    if (custom[2] === "Keyword") return custom[1];
+    if (custom[2] === "Task Text") return "Custom state task";
+    return "◆";
+  }
+
+  return scopeName;
 }
 
 module.exports = {

--- a/org-vscode/out/workflowStateScopes.js
+++ b/org-vscode/out/workflowStateScopes.js
@@ -1,0 +1,154 @@
+"use strict";
+
+// Maps workflow state keywords to TextMate scope names.
+//
+// The bundled grammar only knows the five built-in keywords, so user-defined
+// states get generated scope names that are themed via editor decorations
+// (see customStateDecorations.js) rather than by the static grammar.
+
+const BUILTIN_STATE_SCOPES = {
+  TODO: {
+    symbol: "constant.character.todo.vso",
+    keyword: "keyword.control.todo.vso",
+    taskText: "string.task.todo.vso"
+  },
+  IN_PROGRESS: {
+    symbol: "constant.character.in_progress.vso",
+    keyword: ["keyword.control.in_progress.vso", "support.constant.in_progress.vso"],
+    taskText: "string.task.in_progress.vso"
+  },
+  CONTINUED: {
+    symbol: "constant.character.continued.vso",
+    keyword: ["keyword.control.continued.vso", "markup.quote.continued.vso"],
+    taskText: "string.task.continued.vso"
+  },
+  DONE: {
+    symbol: "constant.character.done.vso",
+    keyword: ["keyword.control.done.vso", "entity.name.function.vso"],
+    taskText: "string.task.done.vso"
+  },
+  ABANDONED: {
+    symbol: "constant.character.abandoned.vso",
+    keyword: "keyword.control.abandoned.vso",
+    taskText: "string.task.abandoned.vso"
+  }
+};
+
+// Deterministic fallback palette so multiple custom states don't all look alike.
+const CUSTOM_DEFAULT_PALETTE = [
+  { symbol: "#C586C0", keyword: "#C586C0", taskText: "#E6CCE4" },
+  { symbol: "#4EC9B0", keyword: "#4EC9B0", taskText: "#C7ECE4" },
+  { symbol: "#DCDCAA", keyword: "#DCDCAA", taskText: "#EFEFD2" },
+  { symbol: "#569CD6", keyword: "#569CD6", taskText: "#CBE0F2" },
+  { symbol: "#D7BA7D", keyword: "#D7BA7D", taskText: "#EFE3CB" },
+  { symbol: "#F7CA18", keyword: "#F7CA18", taskText: "#FBEBB1" }
+];
+
+function normalizeKeyword(keyword) {
+  if (typeof keyword !== "string") return "";
+  return keyword.trim().toUpperCase();
+}
+
+function isBuiltinStateKeyword(keyword) {
+  return Object.prototype.hasOwnProperty.call(BUILTIN_STATE_SCOPES, normalizeKeyword(keyword));
+}
+
+function sanitizeKeywordForScope(keyword) {
+  return normalizeKeyword(keyword)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function paletteForKeyword(keyword) {
+  const slug = sanitizeKeywordForScope(keyword);
+  let hash = 0;
+  for (let i = 0; i < slug.length; i++) {
+    hash = (hash * 31 + slug.charCodeAt(i)) % 100000;
+  }
+  return CUSTOM_DEFAULT_PALETTE[hash % CUSTOM_DEFAULT_PALETTE.length];
+}
+
+/**
+ * Returns the scope names used to theme a workflow state, or null for
+ * keywords that cannot produce a usable scope slug.
+ */
+function getScopesForKeyword(keyword) {
+  const normalized = normalizeKeyword(keyword);
+  if (!normalized) return null;
+
+  if (isBuiltinStateKeyword(normalized)) {
+    return { keyword: normalized, isBuiltin: true, scopes: BUILTIN_STATE_SCOPES[normalized] };
+  }
+
+  const slug = sanitizeKeywordForScope(normalized);
+  if (!slug) return null;
+
+  return {
+    keyword: normalized,
+    isBuiltin: false,
+    scopes: {
+      symbol: `constant.character.custom.${slug}.vso`,
+      keyword: `keyword.control.custom.${slug}.vso`,
+      taskText: `string.task.custom.${slug}.vso`
+    }
+  };
+}
+
+/**
+ * Builds Syntax Color Customizer rows and groups for user-defined workflow states.
+ * Built-in states are skipped because the static defaults already cover them.
+ */
+function buildCustomStateColorEntries(states) {
+  const list = Array.isArray(states) ? states : [];
+  const colors = {};
+  const groups = {};
+  const seen = new Set();
+
+  for (const state of list) {
+    const keyword = normalizeKeyword(state && state.keyword);
+    if (!keyword || seen.has(keyword)) continue;
+    if (isBuiltinStateKeyword(keyword)) continue;
+
+    const descriptor = getScopesForKeyword(keyword);
+    if (!descriptor) continue;
+
+    seen.add(keyword);
+
+    const palette = paletteForKeyword(keyword);
+    const symbolName = `${keyword} Symbol`;
+    const keywordName = `${keyword} Keyword`;
+    const taskTextName = `${keyword} Task Text`;
+
+    colors[symbolName] = {
+      scope: descriptor.scopes.symbol,
+      foreground: palette.symbol,
+      background: "",
+      fontStyle: "bold"
+    };
+    colors[keywordName] = {
+      scope: descriptor.scopes.keyword,
+      foreground: palette.keyword,
+      background: "",
+      fontStyle: "bold"
+    };
+    colors[taskTextName] = {
+      scope: descriptor.scopes.taskText,
+      foreground: palette.taskText,
+      background: "",
+      fontStyle: ""
+    };
+
+    groups[`${keyword} Tasks (custom)`] = [symbolName, keywordName, taskTextName];
+  }
+
+  return { colors, groups };
+}
+
+module.exports = {
+  BUILTIN_STATE_SCOPES,
+  isBuiltinStateKeyword,
+  sanitizeKeywordForScope,
+  getScopesForKeyword,
+  buildCustomStateColorEntries
+};

--- a/org-vscode/test/suite/asterisk-mode-functional.test.js
+++ b/org-vscode/test/suite/asterisk-mode-functional.test.js
@@ -127,6 +127,55 @@ suite('Asterisk-mode functional behavior', function () {
     }
   });
 
+  test('Checkbox items rotate workflow keywords in place', async () => {
+    const contents = [
+      '* TODO Parent task',
+      '  - [ ] First checkbox',
+      '  - [ ] Second checkbox',
+      ''
+    ].join('\n');
+
+    const uri = await writeTempVsoFile(contents);
+    const { doc, editor } = await openFileInEditor(uri);
+
+    setCursor(editor, 1, 0);
+
+    await vscode.commands.executeCommand('extension.toggleStatusRight');
+    await waitFor(() => doc.lineAt(1).text === '  - [ ] TODO First checkbox');
+
+    // The bullet and marker must stay put; the line must never become a heading.
+    assert.ok(
+      !/^\s*\*/.test(doc.lineAt(1).text),
+      `Checkbox must not be converted into a heading. Got: ${doc.lineAt(1).text}`
+    );
+    assert.strictEqual(doc.lineAt(2).text, '  - [ ] Second checkbox', 'sibling checkbox must be untouched');
+
+    await vscode.commands.executeCommand('extension.toggleStatusRight');
+    await waitFor(() => doc.lineAt(1).text === '  - [ ] IN_PROGRESS First checkbox');
+
+    await vscode.commands.executeCommand('extension.toggleStatusLeft');
+    await waitFor(() => doc.lineAt(1).text === '  - [ ] TODO First checkbox');
+  });
+
+  test('Checkbox marker is checked when rotating into DONE', async () => {
+    const contents = [
+      '* TODO Parent task',
+      '  - [ ] CONTINUED Ship it',
+      ''
+    ].join('\n');
+
+    const uri = await writeTempVsoFile(contents);
+    const { doc, editor } = await openFileInEditor(uri);
+
+    setCursor(editor, 1, 0);
+
+    await vscode.commands.executeCommand('extension.toggleStatusRight');
+    await waitFor(() => doc.lineAt(1).text === '  - [X] DONE Ship it');
+
+    await vscode.commands.executeCommand('extension.toggleStatusLeft');
+    await waitFor(() => doc.lineAt(1).text === '  - [ ] CONTINUED Ship it');
+  });
+
   test('Auto-move done stays in the local sibling group when heading text is duplicated', async () => {
     const cfg = vscode.workspace.getConfiguration('Org-vscode');
     const workflowBefore = cfg.inspect('workflowStates') || {};

--- a/org-vscode/test/unit/checkbox-keywords.test.js
+++ b/org-vscode/test/unit/checkbox-keywords.test.js
@@ -1,0 +1,138 @@
+const assert = require('assert');
+const path = require('path');
+
+const outDir = path.join(__dirname, '..', '..', 'out');
+const {
+  isCheckboxLine,
+  parseCheckboxLine,
+  findCheckboxKeyword,
+  buildCheckboxLine,
+  rotateCheckboxKeyword
+} = require(path.join(outDir, 'checkboxKeywords.js'));
+const { createWorkflowRegistry } = require(path.join(outDir, 'workflowStates.js'));
+
+const registry = createWorkflowRegistry(undefined);
+
+function testDetectsCheckboxLines() {
+  assert.strictEqual(isCheckboxLine('  - [ ] plain checkbox'), true);
+  assert.strictEqual(isCheckboxLine('  - [X] done checkbox'), true);
+  assert.strictEqual(isCheckboxLine('  1. [-] ordered partial'), true);
+  assert.strictEqual(isCheckboxLine('  * TODO a heading'), false);
+  assert.strictEqual(isCheckboxLine('  - a plain bullet'), false);
+}
+
+function testParsesKeywordOnCheckbox() {
+  const parsed = parseCheckboxLine('    - [ ] TODO Write the spec', registry);
+  assert.ok(parsed, 'expected checkbox to parse');
+  assert.strictEqual(parsed.indent, '    ');
+  assert.strictEqual(parsed.bullet, '-');
+  assert.strictEqual(parsed.state, ' ');
+  assert.strictEqual(parsed.keyword, 'TODO');
+  assert.strictEqual(parsed.text, 'Write the spec');
+}
+
+function testParsesCheckboxWithoutKeyword() {
+  const parsed = parseCheckboxLine('  - [ ] Just text', registry);
+  assert.strictEqual(parsed.keyword, null);
+  assert.strictEqual(parsed.text, 'Just text');
+  assert.strictEqual(findCheckboxKeyword('  - [ ] Just text', registry), null);
+}
+
+function testDoesNotTreatSimilarWordAsKeyword() {
+  const parsed = parseCheckboxLine('  - [ ] TODOS are not keywords', registry);
+  assert.strictEqual(parsed.keyword, null, 'TODOS must not match the TODO keyword');
+}
+
+function testRoundTripBuild() {
+  const line = '  - [X] DONE Ship it';
+  const parsed = parseCheckboxLine(line, registry);
+  assert.strictEqual(buildCheckboxLine(parsed), line);
+}
+
+function testRotateAddsFirstKeyword() {
+  const result = rotateCheckboxKeyword('  - [ ] Write the spec', 'right', registry);
+  assert.strictEqual(result.keyword, 'TODO');
+  assert.strictEqual(result.text, '  - [ ] TODO Write the spec');
+  assert.strictEqual(result.changed, true);
+}
+
+function testRotatePreservesBulletAndMarker() {
+  const result = rotateCheckboxKeyword('    - [ ] TODO Write the spec', 'right', registry);
+  assert.strictEqual(result.keyword, 'IN_PROGRESS');
+  assert.strictEqual(result.text, '    - [ ] IN_PROGRESS Write the spec');
+  assert.ok(!/^\s*\*/.test(result.text), 'must never convert a checkbox into a heading');
+}
+
+function testRotateIntoDoneChecksTheBox() {
+  const result = rotateCheckboxKeyword('  - [ ] CONTINUED Ship it', 'right', registry);
+  assert.strictEqual(result.keyword, 'DONE');
+  assert.strictEqual(result.text, '  - [X] DONE Ship it');
+}
+
+function testAbandoningACompletedBoxUnchecksIt() {
+  const result = rotateCheckboxKeyword('  - [X] DONE Ship it', 'right', registry);
+  assert.strictEqual(result.keyword, 'ABANDONED');
+  assert.strictEqual(result.text, '  - [ ] ABANDONED Ship it');
+}
+
+function testRotateOutOfDoneUnchecksTheBox() {
+  const result = rotateCheckboxKeyword('  - [X] DONE Ship it', 'left', registry);
+  assert.strictEqual(result.keyword, 'CONTINUED');
+  assert.strictEqual(result.text, '  - [ ] CONTINUED Ship it');
+}
+
+function testRotateWrapsThroughNoKeyword() {
+  // Last keyword -> no keyword, so a keyword can always be removed again.
+  const result = rotateCheckboxKeyword('  - [ ] ABANDONED Drop it', 'right', registry);
+  assert.strictEqual(result.keyword, null);
+  assert.strictEqual(result.text, '  - [ ] Drop it');
+}
+
+function testRotateLeftFromNoKeywordPicksLast() {
+  // ABANDONED is done-like but does not stamp CLOSED, so the box stays unchecked.
+  const result = rotateCheckboxKeyword('  - [ ] Drop it', 'left', registry);
+  assert.strictEqual(result.keyword, 'ABANDONED');
+  assert.strictEqual(result.text, '  - [ ] ABANDONED Drop it');
+}
+
+function testRotateIgnoresNonCheckboxLines() {
+  assert.strictEqual(rotateCheckboxKeyword('* TODO A heading', 'right', registry), null);
+}
+
+function testCustomWorkflowKeywordsAreSupported() {
+  const customRegistry = createWorkflowRegistry([
+    { keyword: 'NEXT' },
+    { keyword: 'EXAMPLE_STATE' },
+    { keyword: 'DONE', isDoneLike: true, stampsClosed: true }
+  ]);
+
+  const result = rotateCheckboxKeyword('  - [ ] NEXT Do the thing', 'right', customRegistry);
+  assert.strictEqual(result.keyword, 'EXAMPLE_STATE');
+  assert.strictEqual(result.text, '  - [ ] EXAMPLE_STATE Do the thing');
+}
+
+function testKeywordOnlyCheckboxHasNoTrailingSpace() {
+  const result = rotateCheckboxKeyword('  - [ ] ', 'right', registry);
+  assert.strictEqual(result.text, '  - [ ] TODO');
+}
+
+module.exports = {
+  name: 'unit/checkbox-keywords',
+  run() {
+    testDetectsCheckboxLines();
+    testParsesKeywordOnCheckbox();
+    testParsesCheckboxWithoutKeyword();
+    testDoesNotTreatSimilarWordAsKeyword();
+    testRoundTripBuild();
+    testRotateAddsFirstKeyword();
+    testRotatePreservesBulletAndMarker();
+    testRotateIntoDoneChecksTheBox();
+    testAbandoningACompletedBoxUnchecksIt();
+    testRotateOutOfDoneUnchecksTheBox();
+    testRotateWrapsThroughNoKeyword();
+    testRotateLeftFromNoKeywordPicksLast();
+    testRotateIgnoresNonCheckboxLines();
+    testCustomWorkflowKeywordsAreSupported();
+    testKeywordOnlyCheckboxHasNoTrailingSpace();
+  }
+};

--- a/org-vscode/test/unit/run.js
+++ b/org-vscode/test/unit/run.js
@@ -14,6 +14,8 @@ const tests = [
   require(path.join(__dirname, 'checkbox-cookie-toggle.test.js')),
   require(path.join(__dirname, 'checkbox-auto-done.test.js')),
   require(path.join(__dirname, 'checkbox-toggle.test.js')),
+  require(path.join(__dirname, 'checkbox-keywords.test.js')),
+  require(path.join(__dirname, 'workflow-state-scopes.test.js')),
   require(path.join(__dirname, 'move-block.test.js')),
   require(path.join(__dirname, 'org-properties.test.js')),
   require(path.join(__dirname, 'smart-insert-new-element.test.js')),

--- a/org-vscode/test/unit/workflow-state-scopes.test.js
+++ b/org-vscode/test/unit/workflow-state-scopes.test.js
@@ -1,0 +1,114 @@
+const assert = require('assert');
+const path = require('path');
+
+const outDir = path.join(__dirname, '..', '..', 'out');
+const {
+  isBuiltinStateKeyword,
+  sanitizeKeywordForScope,
+  getScopesForKeyword,
+  buildCustomStateColorEntries
+} = require(path.join(outDir, 'workflowStateScopes.js'));
+
+function testIdentifiesBuiltins() {
+  assert.strictEqual(isBuiltinStateKeyword('TODO'), true);
+  assert.strictEqual(isBuiltinStateKeyword('in_progress'), true);
+  assert.strictEqual(isBuiltinStateKeyword('ABANDONED'), true);
+  assert.strictEqual(isBuiltinStateKeyword('EXAMPLE_STATE'), false);
+  assert.strictEqual(isBuiltinStateKeyword(''), false);
+}
+
+function testSanitizesKeywords() {
+  assert.strictEqual(sanitizeKeywordForScope('EXAMPLE_STATE'), 'example_state');
+  assert.strictEqual(sanitizeKeywordForScope('Waiting-On'), 'waiting_on');
+  assert.strictEqual(sanitizeKeywordForScope('  NEXT  '), 'next');
+  assert.strictEqual(sanitizeKeywordForScope('!!!'), '');
+}
+
+function testBuiltinScopesAreStable() {
+  const todo = getScopesForKeyword('TODO');
+  assert.strictEqual(todo.isBuiltin, true);
+  assert.strictEqual(todo.scopes.keyword, 'keyword.control.todo.vso');
+  assert.strictEqual(todo.scopes.symbol, 'constant.character.todo.vso');
+  assert.strictEqual(todo.scopes.taskText, 'string.task.todo.vso');
+}
+
+function testCustomScopesAreGenerated() {
+  const custom = getScopesForKeyword('EXAMPLE_STATE');
+  assert.strictEqual(custom.isBuiltin, false);
+  assert.strictEqual(custom.keyword, 'EXAMPLE_STATE');
+  assert.strictEqual(custom.scopes.symbol, 'constant.character.custom.example_state.vso');
+  assert.strictEqual(custom.scopes.keyword, 'keyword.control.custom.example_state.vso');
+  assert.strictEqual(custom.scopes.taskText, 'string.task.custom.example_state.vso');
+}
+
+function testUnusableKeywordReturnsNull() {
+  assert.strictEqual(getScopesForKeyword('!!!'), null);
+  assert.strictEqual(getScopesForKeyword(''), null);
+}
+
+function testBuildsEntriesOnlyForCustomStates() {
+  const { colors, groups } = buildCustomStateColorEntries([
+    { keyword: 'TODO' },
+    { keyword: 'DONE' },
+    { keyword: 'EXAMPLE_STATE' }
+  ]);
+
+  assert.ok(colors['EXAMPLE_STATE Keyword'], 'custom keyword row should exist');
+  assert.ok(colors['EXAMPLE_STATE Symbol'], 'custom symbol row should exist');
+  assert.ok(colors['EXAMPLE_STATE Task Text'], 'custom task text row should exist');
+  assert.strictEqual(colors['TODO Keyword'], undefined, 'built-ins already have static rows');
+
+  assert.deepStrictEqual(groups['EXAMPLE_STATE Tasks (custom)'], [
+    'EXAMPLE_STATE Symbol',
+    'EXAMPLE_STATE Keyword',
+    'EXAMPLE_STATE Task Text'
+  ]);
+
+  assert.strictEqual(
+    colors['EXAMPLE_STATE Keyword'].scope,
+    'keyword.control.custom.example_state.vso'
+  );
+  assert.ok(/^#[0-9A-Fa-f]{6}$/.test(colors['EXAMPLE_STATE Keyword'].foreground));
+}
+
+function testDeduplicatesAndSkipsInvalid() {
+  const { colors } = buildCustomStateColorEntries([
+    { keyword: 'NEXT' },
+    { keyword: 'next' },
+    { keyword: '' },
+    null
+  ]);
+
+  const keys = Object.keys(colors).filter((k) => k.startsWith('NEXT '));
+  assert.strictEqual(keys.length, 3, 'duplicate keywords should only produce one set of rows');
+}
+
+function testDefaultColorsAreDeterministic() {
+  const first = buildCustomStateColorEntries([{ keyword: 'EXAMPLE_STATE' }]);
+  const second = buildCustomStateColorEntries([{ keyword: 'EXAMPLE_STATE' }]);
+  assert.strictEqual(
+    first.colors['EXAMPLE_STATE Keyword'].foreground,
+    second.colors['EXAMPLE_STATE Keyword'].foreground
+  );
+}
+
+function testHandlesNonArrayInput() {
+  const { colors, groups } = buildCustomStateColorEntries(undefined);
+  assert.deepStrictEqual(colors, {});
+  assert.deepStrictEqual(groups, {});
+}
+
+module.exports = {
+  name: 'unit/workflow-state-scopes',
+  run() {
+    testIdentifiesBuiltins();
+    testSanitizesKeywords();
+    testBuiltinScopesAreStable();
+    testCustomScopesAreGenerated();
+    testUnusableKeywordReturnsNull();
+    testBuildsEntriesOnlyForCustomStates();
+    testDeduplicatesAndSkipsInvalid();
+    testDefaultColorsAreDeterministic();
+    testHandlesNonArrayInput();
+  }
+};

--- a/org-vscode/vso.tmLanguage.json
+++ b/org-vscode/vso.tmLanguage.json
@@ -385,6 +385,7 @@
           "end": "$",
           "patterns": [
             { "include": "#org_list_checkbox" },
+            { "include": "#org_list_keyword" },
             { "include": "#org_emphasis" },
             { "include": "#org_links" }
           ]
@@ -399,9 +400,35 @@
           "end": "$",
           "patterns": [
             { "include": "#org_list_checkbox" },
+            { "include": "#org_list_keyword" },
             { "include": "#org_emphasis" },
             { "include": "#org_links" }
           ]
+        }
+      ]
+    },
+    "org_list_keyword": {
+      "comment": "Workflow keyword directly after a checkbox marker, e.g. - [ ] TODO text",
+      "patterns": [
+        {
+          "name": "keyword.control.todo.vso",
+          "match": "(?<=\\[[ xX-]\\]\\s)TODO\\b"
+        },
+        {
+          "name": "keyword.control.in_progress.vso",
+          "match": "(?<=\\[[ xX-]\\]\\s)IN_PROGRESS\\b"
+        },
+        {
+          "name": "keyword.control.continued.vso",
+          "match": "(?<=\\[[ xX-]\\]\\s)CONTINUED\\b"
+        },
+        {
+          "name": "keyword.control.done.vso",
+          "match": "(?<=\\[[ xX-]\\]\\s)DONE\\b"
+        },
+        {
+          "name": "keyword.control.abandoned.vso",
+          "match": "(?<=\\[[ xX-]\\]\\s)ABANDONED\\b"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -550,6 +550,18 @@
 					"default": true,
 					"description": "Decorate entire task heading lines with a background color based on TODO keyword (uses your editor.tokenColorCustomizations TextMate rule background for the keyword scopes)."
 				},
+				"Org-vscode.enableCheckboxKeywords": {
+					"type": "boolean",
+					"order": 8.1,
+					"default": true,
+					"description": "Allow checkbox list items to carry a workflow keyword (for example `- [ ] TODO Write the spec`). Ctrl+Right / Ctrl+Left then rotates the keyword on the checkbox instead of treating the line as a heading."
+				},
+				"Org-vscode.decorateCustomWorkflowStates": {
+					"type": "boolean",
+					"order": 8.15,
+					"default": true,
+					"description": "Apply your Syntax Color Customizer colors to user-defined workflow states using editor decorations. Required because the bundled syntax grammar only knows the built-in keywords."
+				},
 				"Org-vscode.decorateHeadingScheduledDates": {
 					"type": "boolean",
 					"order": 8.25,


### PR DESCRIPTION
﻿Fixes #116

## Summary

### Workflow keywords on checkbox items

Checkboxes can now carry workflow keywords and rotate them in place with `Ctrl+Right` / `Ctrl+Left`:

```org
- [ ] TODO Draft the plan
- [ ] IN_PROGRESS Review it
- [X] DONE Ship it
```

- preserves the bullet and `[ ]` marker (never converts the line into a heading)
- includes a no-keyword step so the keyword can be removed
- checks the box when entering a state that stamps CLOSED; unchecks when leaving it
- ABANDONED stays unchecked because it is not a completion
- supports custom workflow states
- checkbox keywords remain ordinary checklist items, never task headings in Agenda/Tagged Agenda/stats
- opt-out setting: `Org-vscode.enableCheckboxKeywords`

### Syntax colors for custom workflow states

- every user-defined workflow state gets Symbol / Keyword / Task Text rows in the Syntax Color Customizer
- rows appear immediately after **Save Workflow**, no reload needed
- each custom state gets a deterministic distinct starter color
- saved colors are applied in the editor via decorations because the static TextMate grammar cannot know runtime keywords
- opt-out setting: `Org-vscode.decorateCustomWorkflowStates`
- built-in workflow keywords after checkbox markers are now scoped by the grammar

## Tests

- `npm run test:unit` — 34 passing
- `npm test` — 32 passing in the extension host

## Documentation

- README feature highlights
- how-to sections for checkbox keywords and custom state coloring
- roadmap entries
- Unreleased changelog entry

## Privacy

- all committed test fixtures use generic task names
- no personal Org content is included
