### PR TITLE
Fix checkbox workflow hierarchy, cookies, and task colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Most editing shortcuts support multi-line selection: highlight multiple task lin
 | `Ctrl + Alt + S`     | Schedule a task (selection-aware)                      |
 | `Ctrl + Alt + D`     | Add deadline to task (selection-aware)                 |
 | `Ctrl + Alt + X`     | Toggle checkbox item (selection-aware)                 |
+| `Ctrl + Alt + K`     | Add, change, or remove a statistics cookie             |
 | `Alt + Shift + →`    | Smart date forward (selection-aware)                   |
 | `Alt + Shift + ←`    | Smart date backward (selection-aware)                  |
 | `Ctrl + Shift + →`   | Deadline date forward (selection-aware)                |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,13 @@
 
 `Added / Enhanced`
 
-- (none)
+- **Checkbox workflow hierarchy:** Cycling a checkbox workflow item into or out of `DONE` now updates ancestor checkbox markers (`[ ]`, `[-]`, and `[X]`) through the same hierarchy logic as ordinary checkbox toggles. Statistics cookies refresh from the reconciled state, and parent task auto-completion continues to account for both checkboxes and child TODO headings.
+- **Checkbox workflow task colors:** Built-in workflow keywords and their trailing checkbox task text now receive the corresponding task-state TextMate scopes in the grammar actually shipped by the extension. Custom workflow states continue to use dynamic decorations.
+- **Statistics cookie shortcut:** Restored the statistics-cookie command contribution and added `Ctrl + Alt + K` to add, switch, or remove a cookie from a heading or list item.
+
+`Tests`
+
+- Added regressions for workflow-driven ancestor markers, child TODO completion, shipped grammar scopes, and the statistics-cookie command/keybinding contribution.
 
 
 # [2.2.29] 08-22-26

--- a/docs/howto.md
+++ b/docs/howto.md
@@ -647,6 +647,8 @@ Column View stores your visible columns, sort settings, and selected scope in wo
 
 Checkbox completion stats are cookie-driven (Emacs-style): add `[/]` (fraction) or `[%]` (percent) to the end of a heading or list item to show stats (Org-vscode renders them as `[n/m]` or `[p%]`).
 
+Press `Ctrl + Alt + K` on a heading or list item to add, switch, or remove its statistics cookie.
+
 <img src="https://github.com/realdestroyer/org-vscode/blob/master/Images/checkbox-example.png?raw=true" width="900" />
 
 ### Toggle a checkbox from the keyboard
@@ -698,6 +700,7 @@ Behavior:
 - The cycle includes a **"no keyword"** step, so you can always remove a keyword again.
 - Rotating into a state that stamps `CLOSED` (by default `DONE`) checks the box.
 - Rotating back out of that state unchecks the box.
+- Marker changes update ancestor checkbox states (`[ ]`, `[-]`, and `[X]`) and statistics cookies just like the checkbox toggle command.
 - States that are done-like but do **not** stamp `CLOSED` (by default `ABANDONED`) leave the box untouched, because abandoning an item is not the same as completing it.
 - Your custom workflow states work here too.
 

--- a/org-vscode/out/checkboxToggle.js
+++ b/org-vscode/out/checkboxToggle.js
@@ -301,6 +301,33 @@ function computeCheckboxSetEdits(lines, lineIndices0, desiredStateChar) {
 }
 
 /**
+ * Applies a rewritten checkbox line and reconciles its subtree/ancestors when
+ * the rewrite changes the checkbox marker.
+ */
+function computeCheckboxLineChangeEdits(lines, lineIndex0, newText) {
+  const safeLines = Array.isArray(lines) ? lines.slice() : [];
+  const idx = Number(lineIndex0);
+  if (!Number.isInteger(idx) || idx < 0 || idx >= safeLines.length) return [];
+
+  const previous = parseCheckboxItem(safeLines[idx]);
+  const next = parseCheckboxItem(newText);
+  if (!previous || !next) return [];
+
+  const edits = new Map([[idx, String(newText)]]);
+  safeLines[idx] = String(newText);
+
+  if (String(previous.state).toLowerCase() !== String(next.state).toLowerCase()) {
+    for (const edit of computeCheckboxSetEdits(safeLines, [idx], next.state)) {
+      edits.set(edit.lineIndex, edit.newText);
+    }
+  }
+
+  return Array.from(edits.entries())
+    .sort((a, b) => a[0] - b[0])
+    .map(([lineIndex, changedText]) => ({ lineIndex, newText: changedText }));
+}
+
+/**
  * Computes line edits to bulk-toggle checkbox items across multiple line indices.
  *
  * Rule:
@@ -331,5 +358,6 @@ function computeCheckboxBulkToggleEdits(lines, lineIndices0) {
 module.exports = {
   computeCheckboxToggleEdits,
   computeCheckboxSetEdits,
+  computeCheckboxLineChangeEdits,
   computeCheckboxBulkToggleEdits
 };

--- a/org-vscode/out/keywordLeft.js
+++ b/org-vscode/out/keywordLeft.js
@@ -12,6 +12,7 @@ const { normalizeBodyIndentation } = require("./indentUtils");
 const { applyAutoMoveDone } = require("./doneTaskAutoMove");
 const { findIncompleteChildTask } = require("./todoDependencies");
 const checkboxKeywords = require("./checkboxKeywords");
+const { computeCheckboxLineChangeEdits } = require("./checkboxToggle");
 
 function buildPlanningBody(planning) {
   const parts = [];
@@ -75,8 +76,12 @@ module.exports = async function () {
     if (enableCheckboxKeywords && checkboxKeywords.isCheckboxLine(currentLine.text)) {
       const rotated = checkboxKeywords.rotateCheckboxKeyword(currentLine.text, "left", workflowRegistry);
       if (rotated && rotated.changed) {
+        const lines = document.getText().split(/\r?\n/);
+        const edits = computeCheckboxLineChangeEdits(lines, lineNumber, rotated.text);
         const checkboxEdit = new vscode.WorkspaceEdit();
-        checkboxEdit.replace(document.uri, currentLine.range, rotated.text);
+        for (const edit of edits) {
+          checkboxEdit.replace(document.uri, document.lineAt(edit.lineIndex).range, edit.newText);
+        }
         await vscode.workspace.applyEdit(checkboxEdit);
       }
       continue;

--- a/org-vscode/out/keywordRight.js
+++ b/org-vscode/out/keywordRight.js
@@ -12,6 +12,7 @@ const { normalizeBodyIndentation } = require("./indentUtils");
 const { applyAutoMoveDone } = require("./doneTaskAutoMove");
 const { findIncompleteChildTask } = require("./todoDependencies");
 const checkboxKeywords = require("./checkboxKeywords");
+const { computeCheckboxLineChangeEdits } = require("./checkboxToggle");
 
 function buildPlanningBody(planning) {
   const parts = [];
@@ -75,8 +76,12 @@ module.exports = async function () {
     if (enableCheckboxKeywords && checkboxKeywords.isCheckboxLine(currentLine.text)) {
       const rotated = checkboxKeywords.rotateCheckboxKeyword(currentLine.text, "right", workflowRegistry);
       if (rotated && rotated.changed) {
+        const lines = document.getText().split(/\r?\n/);
+        const edits = computeCheckboxLineChangeEdits(lines, lineNumber, rotated.text);
         const checkboxEdit = new vscode.WorkspaceEdit();
-        checkboxEdit.replace(document.uri, currentLine.range, rotated.text);
+        for (const edit of edits) {
+          checkboxEdit.replace(document.uri, document.lineAt(edit.lineIndex).range, edit.newText);
+        }
         await vscode.workspace.applyEdit(checkboxEdit);
       }
       continue;

--- a/org-vscode/test/suite/asterisk-mode-functional.test.js
+++ b/org-vscode/test/suite/asterisk-mode-functional.test.js
@@ -160,20 +160,30 @@ suite('Asterisk-mode functional behavior', function () {
   test('Checkbox marker is checked when rotating into DONE', async () => {
     const contents = [
       '* TODO Parent task',
-      '  - [ ] CONTINUED Ship it',
+      '  - [ ] Parent checkbox',
+      '    - [ ] CONTINUED First child',
+      '    - [ ] CONTINUED Second child',
       ''
     ].join('\n');
 
     const uri = await writeTempVsoFile(contents);
     const { doc, editor } = await openFileInEditor(uri);
 
-    setCursor(editor, 1, 0);
+    setCursor(editor, 2, 0);
 
     await vscode.commands.executeCommand('extension.toggleStatusRight');
-    await waitFor(() => doc.lineAt(1).text === '  - [X] DONE Ship it');
+    await waitFor(() => doc.lineAt(2).text === '    - [X] DONE First child');
+    assert.strictEqual(doc.lineAt(1).text, '  - [-] Parent checkbox');
 
+    setCursor(editor, 3, 0);
+    await vscode.commands.executeCommand('extension.toggleStatusRight');
+    await waitFor(() => doc.lineAt(3).text === '    - [X] DONE Second child');
+    assert.strictEqual(doc.lineAt(1).text, '  - [X] Parent checkbox');
+
+    setCursor(editor, 2, 0);
     await vscode.commands.executeCommand('extension.toggleStatusLeft');
-    await waitFor(() => doc.lineAt(1).text === '  - [ ] CONTINUED Ship it');
+    await waitFor(() => doc.lineAt(2).text === '    - [ ] CONTINUED First child');
+    assert.strictEqual(doc.lineAt(1).text, '  - [-] Parent checkbox');
   });
 
   test('Auto-move done stays in the local sibling group when heading text is duplicated', async () => {

--- a/org-vscode/test/unit/checkbox-auto-done.test.js
+++ b/org-vscode/test/unit/checkbox-auto-done.test.js
@@ -37,10 +37,23 @@ function testDoesNotAutoDoneWhenChildSubtaskIncomplete() {
   assert.deepStrictEqual(toMarkDone, [], 'Expected Parent to NOT be marked DONE while a child task is still TODO');
 }
 
+function testAutoDoneAfterChildSubtasksComplete() {
+  const lines = [
+    '* IN_PROGRESS Parent',
+    '  - [X] checklist item',
+    '  ** DONE Completed child task'
+  ];
+
+  const { toMarkDone } = computeHeadingTransitions(lines);
+
+  assert.deepStrictEqual(toMarkDone, [0], 'Expected Parent to be marked DONE after its checkbox and child task complete');
+}
+
 module.exports = {
   name: 'unit/checkbox-auto-done',
   run: () => {
     testTransitionsMarkDoneAndRevertToInProgress();
     testDoesNotAutoDoneWhenChildSubtaskIncomplete();
+    testAutoDoneAfterChildSubtasksComplete();
   }
 };

--- a/org-vscode/test/unit/checkbox-toggle.test.js
+++ b/org-vscode/test/unit/checkbox-toggle.test.js
@@ -1,7 +1,11 @@
 const assert = require('assert');
 const path = require('path');
 
-const { computeCheckboxToggleEdits, computeCheckboxBulkToggleEdits } = require(path.join(__dirname, '..', '..', 'out', 'checkboxToggle.js'));
+const {
+  computeCheckboxToggleEdits,
+  computeCheckboxLineChangeEdits,
+  computeCheckboxBulkToggleEdits
+} = require(path.join(__dirname, '..', '..', 'out', 'checkboxToggle.js'));
 
 function applyEdits(lines, edits) {
   const out = lines.slice();
@@ -73,6 +77,35 @@ function testBulkToggleUnchecksWhenAllChecked() {
   assert.strictEqual(updated[2], '  - [ ] b');
 }
 
+function testWorkflowMarkerChangeUpdatesAncestors() {
+  const lines = [
+    '* H',
+    '  - [ ] Parent',
+    '    - [ ] TODO first',
+    '    - [ ] TODO second'
+  ];
+
+  const edits = computeCheckboxLineChangeEdits(lines, 2, '    - [X] DONE first');
+  const updated = applyEdits(lines, edits);
+
+  assert.strictEqual(updated[1], '  - [-] Parent');
+  assert.strictEqual(updated[2], '    - [X] DONE first');
+}
+
+function testWorkflowKeywordOnlyChangePreservesDescendants() {
+  const lines = [
+    '* H',
+    '  - [ ] TODO Parent',
+    '    - [X] DONE child'
+  ];
+
+  const edits = computeCheckboxLineChangeEdits(lines, 1, '  - [ ] IN_PROGRESS Parent');
+  const updated = applyEdits(lines, edits);
+
+  assert.strictEqual(updated[1], '  - [ ] IN_PROGRESS Parent');
+  assert.strictEqual(updated[2], '    - [X] DONE child');
+}
+
 module.exports = {
   name: 'unit/checkbox-toggle',
   run: () => {
@@ -80,5 +113,7 @@ module.exports = {
     testToggleParentTogglesDescendants();
     testBulkToggleChecksWhenAnyUnchecked();
     testBulkToggleUnchecksWhenAllChecked();
+    testWorkflowMarkerChangeUpdatesAncestors();
+    testWorkflowKeywordOnlyChangePreservesDescendants();
   }
 };

--- a/org-vscode/test/unit/checkbox-workflow-grammar.test.js
+++ b/org-vscode/test/unit/checkbox-workflow-grammar.test.js
@@ -1,0 +1,31 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+function loadGrammar(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function assertCheckboxWorkflowScopes(grammar) {
+  const listPatterns = grammar.repository.org_lists.patterns;
+  for (const listPattern of listPatterns) {
+    const includes = listPattern.patterns.map((pattern) => pattern.include);
+    assert.ok(includes.includes('#org_list_keyword'));
+    assert.ok(includes.includes('#org_list_task_text'));
+  }
+
+  const keywordScopes = grammar.repository.org_list_keyword.patterns.map((pattern) => pattern.name);
+  assert.ok(keywordScopes.includes('keyword.control.in_progress.vso'));
+
+  const taskTextIncludes = grammar.repository.org_list_task_text.patterns.map((pattern) => pattern.include);
+  assert.ok(taskTextIncludes.includes('#task_text_in_progress'));
+}
+
+module.exports = {
+  name: 'unit/checkbox-workflow-grammar',
+  run() {
+    const extensionRoot = path.resolve(__dirname, '..', '..', '..');
+    assertCheckboxWorkflowScopes(loadGrammar(path.join(extensionRoot, 'vso.tmLanguage.json')));
+    assertCheckboxWorkflowScopes(loadGrammar(path.join(extensionRoot, 'org-vscode', 'vso.tmLanguage.json')));
+  }
+};

--- a/org-vscode/test/unit/command-registration.test.js
+++ b/org-vscode/test/unit/command-registration.test.js
@@ -98,6 +98,12 @@ function getContributedCommands(extensionRoot) {
   return commands.map((c) => c && c.command).filter(Boolean);
 }
 
+function getContributedKeybindings(extensionRoot) {
+  const pkgPath = path.join(extensionRoot, 'package.json');
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  return (pkg.contributes && pkg.contributes.keybindings) || [];
+}
+
 function activateExtension(extensionRoot, vscodeMock) {
   const extensionPath = path.join(extensionRoot, 'out', 'extension.js');
   // Ensure we load a fresh copy for each run.
@@ -132,6 +138,12 @@ function testAllContributedCommandsAreRegistered() {
     // Spot checks for historically-regressed commands.
     assert.ok(registered.has('org-vscode.insertTable'), 'org-vscode.insertTable must be registered');
     assert.ok(registered.has('org-vscode.exportCurrentTasks'), 'org-vscode.exportCurrentTasks must be registered');
+    assert.ok(registered.has('extension.toggleCheckboxCookie'), 'statistics cookie command must be registered');
+
+    const cookieBinding = getContributedKeybindings(packageJsonRoot)
+      .find((binding) => binding.command === 'extension.toggleCheckboxCookie');
+    assert.ok(cookieBinding, 'statistics cookie command must have a contributed keybinding');
+    assert.strictEqual(cookieBinding.key, 'ctrl+alt+k');
   });
 }
 

--- a/org-vscode/test/unit/run.js
+++ b/org-vscode/test/unit/run.js
@@ -15,6 +15,7 @@ const tests = [
   require(path.join(__dirname, 'checkbox-auto-done.test.js')),
   require(path.join(__dirname, 'checkbox-toggle.test.js')),
   require(path.join(__dirname, 'checkbox-keywords.test.js')),
+  require(path.join(__dirname, 'checkbox-workflow-grammar.test.js')),
   require(path.join(__dirname, 'workflow-state-scopes.test.js')),
   require(path.join(__dirname, 'move-block.test.js')),
   require(path.join(__dirname, 'org-properties.test.js')),

--- a/org-vscode/vso.tmLanguage.json
+++ b/org-vscode/vso.tmLanguage.json
@@ -386,6 +386,7 @@
           "patterns": [
             { "include": "#org_list_checkbox" },
             { "include": "#org_list_keyword" },
+            { "include": "#org_list_task_text" },
             { "include": "#org_emphasis" },
             { "include": "#org_links" }
           ]
@@ -401,6 +402,7 @@
           "patterns": [
             { "include": "#org_list_checkbox" },
             { "include": "#org_list_keyword" },
+            { "include": "#org_list_task_text" },
             { "include": "#org_emphasis" },
             { "include": "#org_links" }
           ]
@@ -430,6 +432,15 @@
           "name": "keyword.control.abandoned.vso",
           "match": "(?<=\\[[ xX-]\\]\\s)ABANDONED\\b"
         }
+      ]
+    },
+    "org_list_task_text": {
+      "patterns": [
+        { "include": "#task_text_todo" },
+        { "include": "#task_text_in_progress" },
+        { "include": "#task_text_continued" },
+        { "include": "#task_text_done" },
+        { "include": "#task_text_abandoned" }
       ]
     },
     "org_list_checkbox": {

--- a/package.json
+++ b/package.json
@@ -921,6 +921,11 @@
 				"title": "Toggle Checkbox Item"
 			},
 			{
+				"command": "extension.toggleCheckboxCookie",
+				"category": "Org-vscode",
+				"title": "Add, Change, or Remove Statistics Cookie"
+			},
+			{
 				"command": "extension.toggleStatusLeft",
 				"category": "Org-vscode",
 				"title": "Toggle Status Left"
@@ -1005,6 +1010,11 @@
 			{
 				"command": "extension.toggleCheckboxItem",
 				"key": "ctrl+alt+x",
+				"when": "(editorLangId == 'vso' || editorLangId == 'org' || editorLangId == 'vsorg' || editorLangId == 'org-vscode') && editorTextFocus"
+			},
+			{
+				"command": "extension.toggleCheckboxCookie",
+				"key": "ctrl+alt+k",
 				"when": "(editorLangId == 'vso' || editorLangId == 'org' || editorLangId == 'vsorg' || editorLangId == 'org-vscode') && editorTextFocus"
 			},
 			{

--- a/vso.tmLanguage.json
+++ b/vso.tmLanguage.json
@@ -385,6 +385,8 @@
           "end": "$",
           "patterns": [
             { "include": "#org_list_checkbox" },
+            { "include": "#org_list_keyword" },
+            { "include": "#org_list_task_text" },
             { "include": "#org_emphasis" },
             { "include": "#org_links" }
           ]
@@ -399,10 +401,31 @@
           "end": "$",
           "patterns": [
             { "include": "#org_list_checkbox" },
+            { "include": "#org_list_keyword" },
+            { "include": "#org_list_task_text" },
             { "include": "#org_emphasis" },
             { "include": "#org_links" }
           ]
         }
+      ]
+    },
+    "org_list_keyword": {
+      "comment": "Workflow keyword directly after a checkbox marker, e.g. - [ ] TODO text",
+      "patterns": [
+        { "name": "keyword.control.todo.vso", "match": "(?<=\\[[ xX-]\\]\\s)TODO\\b" },
+        { "name": "keyword.control.in_progress.vso", "match": "(?<=\\[[ xX-]\\]\\s)IN_PROGRESS\\b" },
+        { "name": "keyword.control.continued.vso", "match": "(?<=\\[[ xX-]\\]\\s)CONTINUED\\b" },
+        { "name": "keyword.control.done.vso", "match": "(?<=\\[[ xX-]\\]\\s)DONE\\b" },
+        { "name": "keyword.control.abandoned.vso", "match": "(?<=\\[[ xX-]\\]\\s)ABANDONED\\b" }
+      ]
+    },
+    "org_list_task_text": {
+      "patterns": [
+        { "include": "#task_text_todo" },
+        { "include": "#task_text_in_progress" },
+        { "include": "#task_text_continued" },
+        { "include": "#task_text_done" },
+        { "include": "#task_text_abandoned" }
       ]
     },
     "org_list_checkbox": {


### PR DESCRIPTION
Fixes #118

## Summary

- routes workflow-driven checkbox marker changes through the existing checkbox subtree/ancestor reconciliation logic
- updates parent markers to `[ ]`, `[-]`, or `[X]` when child workflow items complete or reopen
- preserves descendants when a workflow keyword changes without changing the checkbox marker
- ships built-in checkbox keyword and trailing task-text scopes in the grammar referenced by `package.json`
- keeps custom workflow state task-text coloring decoration-based
- restores the statistics-cookie command contribution and adds `Ctrl+Alt+K` for add/switch/remove
- confirms parent auto-DONE waits for both checkboxes and child TODO headings

## Tests

- `npm run test:unit` - 35 passing
- `npm test` - 32 passing in the VS Code extension host
- VS Code diagnostics - no errors in changed source, tests, manifest, or grammars

## Documentation

- README shortcut table
- checkbox how-to behavior and cookie shortcut
- Unreleased changelog

## Privacy

- all tests and documentation use generic task text
- no personal Org file content is included