### PR TITLE
Fix explicit DONE reversion from checkbox listener

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+# [Unreleased]
+
+`Fixed`
+
+- **Explicit DONE transitions with incomplete checkboxes:** Heading status commands no longer trigger checkbox auto-DONE reconciliation merely because the heading contains a hyphen or the transition inserts a bracketed `CLOSED` timestamp. Explicitly selecting `DONE` now remains `DONE`; actual checkbox edits still auto-complete or reopen parent tasks when `Org-vscode.autoDoneWhenAllCheckboxesChecked` is enabled.
+
+`Tests`
+
+- Added unit and extension-host regressions for distinguishing checkbox-marker edits from heading and planning-line edits.
+
+
 # [2.2.30] 08-25-26
 
 `Added / Enhanced`

--- a/org-vscode/out/checkboxAutoDone.js
+++ b/org-vscode/out/checkboxAutoDone.js
@@ -8,7 +8,7 @@ const continuedTaskHandler = require("./continuedTaskHandler");
 const { isPlanningLine, parsePlanningFromText, normalizeTagsAfterPlanning, stripInlinePlanning } = require("./orgTagUtils");
 const { applyRepeatersOnCompletion } = require("./repeatedTasks");
 const { computeLogbookInsertion, formatStateChangeEntry } = require("./orgLogbook");
-const { computeHeadingTransitions } = require("./checkboxAutoDoneTransitions");
+const { computeHeadingTransitions, contentChangesTouchCheckbox } = require("./checkboxAutoDoneTransitions");
 const { normalizeBodyIndentation } = require("./indentUtils");
 const { parseHeadingInfo, findSubtreeEndExclusive } = require("./moveBlockUtils");
 const { applyAutoMoveDone } = require("./doneTaskAutoMove");
@@ -424,13 +424,7 @@ function registerCheckboxAutoDone(ctx) {
 
   ctx.subscriptions.push(
     vscode.workspace.onDidChangeTextDocument((event) => {
-      // Only respond when the change likely involves checkboxes.
-      const touchesCheckbox = (event.contentChanges || []).some((c) => {
-        const text = String(c && c.text || "");
-        return text.includes("[") || text.includes("]") || text.includes("-");
-      });
-
-      if (!touchesCheckbox) return;
+      if (!contentChangesTouchCheckbox(event.document, event.contentChanges || [])) return;
       schedule(event.document);
     }),
     vscode.workspace.onDidChangeConfiguration((event) => {

--- a/org-vscode/out/checkboxAutoDoneTransitions.js
+++ b/org-vscode/out/checkboxAutoDoneTransitions.js
@@ -22,6 +22,36 @@ function buildHeadingRegexes(registry) {
   };
 }
 const CHECKBOX_REGEX = /^\s*[-+*]\s+\[( |x|X)\]\s+/;
+const CHECKBOX_CHANGE_REGEX = /^\s*[-+*]\s+\[(?: |x|X|-)\](?:\s+|$)/;
+
+function contentChangesTouchCheckbox(document, contentChanges) {
+  if (!document || !Array.isArray(contentChanges)) return false;
+
+  return contentChanges.some((change) => {
+    const insertedLines = String(change?.text || "").split(/\r?\n/);
+    if (insertedLines.some((line) => CHECKBOX_CHANGE_REGEX.test(line))) {
+      return true;
+    }
+
+    const startLine = change?.range?.start?.line;
+    if (!Number.isInteger(startLine) || !Number.isInteger(document.lineCount)) {
+      return false;
+    }
+
+    const endLine = Math.min(
+      document.lineCount - 1,
+      startLine + Math.max(0, insertedLines.length - 1)
+    );
+
+    for (let lineNumber = Math.max(0, startLine); lineNumber <= endLine; lineNumber++) {
+      if (CHECKBOX_CHANGE_REGEX.test(document.lineAt(lineNumber).text)) {
+        return true;
+      }
+    }
+
+    return false;
+  });
+}
 
 function getHeadingLevel(match) {
   const starsOrSymbol = match[2] || "";
@@ -125,5 +155,6 @@ function computeHeadingTransitions(lines) {
 }
 
 module.exports = {
-  computeHeadingTransitions
+  computeHeadingTransitions,
+  contentChangesTouchCheckbox
 };

--- a/org-vscode/test/suite/asterisk-mode-functional.test.js
+++ b/org-vscode/test/suite/asterisk-mode-functional.test.js
@@ -127,6 +127,48 @@ suite('Asterisk-mode functional behavior', function () {
     }
   });
 
+  test('Explicit DONE survives checkbox auto-DONE listener debounce', async () => {
+    const cfg = vscode.workspace.getConfiguration('Org-vscode');
+    const workflowBefore = cfg.inspect('workflowStates') || {};
+    const autoDoneBefore = cfg.inspect('autoDoneWhenAllCheckboxesChecked') || {};
+    const oldGlobalWorkflowStates = workflowBefore.globalValue;
+    const oldGlobalAutoDone = autoDoneBefore.globalValue;
+
+    await cfg.update(
+      'workflowStates',
+      [
+        { keyword: 'IN_PROGRESS' },
+        { keyword: 'DONE', isDoneLike: true, stampsClosed: true }
+      ],
+      vscode.ConfigurationTarget.Global
+    );
+    await cfg.update('autoDoneWhenAllCheckboxesChecked', true, vscode.ConfigurationTarget.Global);
+
+    try {
+      const uri = await writeTempVsoFile([
+        '* IN_PROGRESS Parent - explicit completion',
+        '  - [ ] Remaining item',
+        ''
+      ].join('\n'));
+      const { doc, editor } = await openFileInEditor(uri);
+      setCursor(editor, 0, 0);
+
+      await vscode.commands.executeCommand('extension.toggleStatusRight');
+      await waitFor(() => doc.lineAt(0).text === '* DONE Parent - explicit completion');
+      await waitFor(() => doc.getText().includes('CLOSED: ['));
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      assert.strictEqual(
+        doc.lineAt(0).text,
+        '* DONE Parent - explicit completion',
+        'checkbox auto-DONE must not reverse an explicit heading status command'
+      );
+    } finally {
+      await cfg.update('workflowStates', oldGlobalWorkflowStates, vscode.ConfigurationTarget.Global);
+      await cfg.update('autoDoneWhenAllCheckboxesChecked', oldGlobalAutoDone, vscode.ConfigurationTarget.Global);
+    }
+  });
+
   test('Checkbox items rotate workflow keywords in place', async () => {
     const contents = [
       '* TODO Parent task',

--- a/org-vscode/test/unit/checkbox-auto-done.test.js
+++ b/org-vscode/test/unit/checkbox-auto-done.test.js
@@ -1,7 +1,64 @@
 const assert = require('assert');
 const path = require('path');
 
-const { computeHeadingTransitions } = require(path.join(__dirname, '..', '..', 'out', 'checkboxAutoDoneTransitions.js'));
+const {
+  computeHeadingTransitions,
+  contentChangesTouchCheckbox
+} = require(path.join(__dirname, '..', '..', 'out', 'checkboxAutoDoneTransitions.js'));
+
+function fakeDocument(lines) {
+  return {
+    lineCount: lines.length,
+    lineAt(lineNumber) {
+      return { text: lines[lineNumber] };
+    }
+  };
+}
+
+function changeAt(line, text) {
+  return {
+    text,
+    range: { start: { line }, end: { line } }
+  };
+}
+
+function testOnlyCheckboxChangesScheduleReconciliation() {
+  assert.strictEqual(
+    contentChangesTouchCheckbox(
+      fakeDocument(['* DONE - Parent task']),
+      [changeAt(0, '* DONE - Parent task')]
+    ),
+    false,
+    'heading text containing a hyphen must not schedule checkbox reconciliation'
+  );
+
+  assert.strictEqual(
+    contentChangesTouchCheckbox(
+      fakeDocument(['  CLOSED: [2026-08-26 Wed 10:00]']),
+      [changeAt(0, '\n  CLOSED: [2026-08-26 Wed 10:00]')]
+    ),
+    false,
+    'a CLOSED timestamp must not schedule checkbox reconciliation'
+  );
+
+  assert.strictEqual(
+    contentChangesTouchCheckbox(
+      fakeDocument(['  - [X] Completed item']),
+      [changeAt(0, 'X')]
+    ),
+    true,
+    'editing a checkbox marker in place must schedule reconciliation'
+  );
+
+  assert.strictEqual(
+    contentChangesTouchCheckbox(
+      fakeDocument(['  - [ ] New item']),
+      [changeAt(0, '  - [ ] New item')]
+    ),
+    true,
+    'inserting a checkbox line must schedule reconciliation'
+  );
+}
 
 function testTransitionsMarkDoneAndRevertToInProgress() {
   const lines = [
@@ -52,6 +109,7 @@ function testAutoDoneAfterChildSubtasksComplete() {
 module.exports = {
   name: 'unit/checkbox-auto-done',
   run: () => {
+    testOnlyCheckboxChangesScheduleReconciliation();
     testTransitionsMarkDoneAndRevertToInProgress();
     testDoesNotAutoDoneWhenChildSubtaskIncomplete();
     testAutoDoneAfterChildSubtasksComplete();


### PR DESCRIPTION
Fixes #120

## Summary

- restricts checkbox auto-DONE scheduling to edits that insert or currently affect an actual checkbox marker
- prevents heading text containing hyphens and bracketed `CLOSED` timestamps from impersonating checkbox changes
- preserves checkbox-driven parent auto-completion and reopen behavior from #43
- confirms this behavior is unrelated to workflow `triggersForward`

## Tests

- `npm run test:unit` - 35 passing
- `npm test` - 33 passing in the VS Code extension host
- focused checkbox auto-DONE unit test - passing
- VS Code diagnostics - clean
- `git diff --check` - clean

## Privacy

- regression fixtures use generic synthetic task text
- no content from personal Org files is included